### PR TITLE
fix(cri): kubectl logs fails for terminated containers (#438)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5548,3 +5548,19 @@ Create→Start→Exit→Restart cycle cleanly. A regression here would cause the
 sidecar restart loop to fail or leave state corrupted, breaking any pod that relies on a
 persistent sidecar co-process (e.g. SPIRE attestation verifiers, log forwarders, secret
 agents).
+
+## `state::tests::stopped_sandbox_with_dead_pause_is_not_reaped` (pelagos-cri unit test)
+**No root required.** Guards the fix for `kubectl logs` failing on terminated containers
+(#438). Verifies that `stale_sandbox_ids` does NOT classify a `NotReady` sandbox
+(explicitly stopped via `StopPodSandbox`) as a phantom even when its pause process is
+dead. **Why it matters:** before this fix, `list_pod_sandbox` reaped the sandbox (and its
+containers) as soon as the pause died, even if `StopPodSandbox` had killed it on purpose.
+`ContainerStatus` then returned `not_found`, breaking `kubectl logs` for any completed pod.
+
+## `state::tests::only_running_sandboxes_with_dead_pause_are_reaped` (pelagos-cri unit test)
+**No root required.** Companion to the #438 fix. Verifies the new `stale_sandbox_ids`
+rule in full: given a mix of Running-live, Running-dead, and NotReady-dead sandboxes, only
+the Running sandbox with a dead pause is classified as stale. **Why it matters:** confirms
+the fix is targeted — legitimate phantoms (pause died unexpectedly while the sandbox was
+still in Running state) are still reaped, while intentionally stopped sandboxes are not,
+preserving the #347 phantom-GC invariant.

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -382,8 +382,10 @@ impl StateInner {
     /// dead "phantom" sandbox is removed within one interval instead of lingering
     /// in the live listing until the next restart. A lingering phantom is exactly
     /// what the kubelet discovers as an orphan and garbage-collects — the path
-    /// that deleted the host `/bin` (#347). Keys on pause-liveness, not the
-    /// recorded `state`, so it reaps both Ready-but-dead and NotReady-but-dead.
+    /// that deleted the host `/bin` (#347). Keys on pause-liveness AND sandbox
+    /// state: only Running sandboxes with a dead pause are phantoms; a NotReady
+    /// sandbox whose pause is dead was explicitly stopped via StopPodSandbox and
+    /// must survive until RemovePodSandbox is called (#438).
     pub(crate) fn reap_stale_sandboxes<F: Fn(i32) -> bool>(&mut self, is_alive: F) -> Vec<String> {
         let stale = stale_sandbox_ids(&self.sandboxes, is_alive);
         for sid in &stale {
@@ -485,7 +487,12 @@ pub(crate) fn stale_sandbox_ids<F: Fn(i32) -> bool>(
 ) -> Vec<String> {
     sandboxes
         .values()
-        .filter(|s| s.pause_pid > 0 && !is_alive(s.pause_pid))
+        // Only reap Running sandboxes whose pause has died unexpectedly.
+        // A NotReady sandbox was explicitly stopped via StopPodSandbox and is
+        // waiting for RemovePodSandbox to clean it up. Reaping it early removes
+        // its containers from state, causing ContainerStatus to return not_found
+        // and breaking `kubectl logs` for terminated pods (#438).
+        .filter(|s| s.state == SandboxState::Running && s.pause_pid > 0 && !is_alive(s.pause_pid))
         .map(|s| s.id.clone())
         .collect()
 }
@@ -673,6 +680,55 @@ mod tests {
                  "state":"Running","exit_code":0}}"#
         );
         serde_json::from_str(&json).expect("valid container json")
+    }
+
+    /// Build a CriSandbox that has been explicitly stopped via StopPodSandbox
+    /// (state=NotReady, pause already dead) — as opposed to a phantom whose pause
+    /// died unexpectedly.
+    fn stopped_sandbox(id: &str, pause_pid: i32) -> CriSandbox {
+        let json = format!(
+            r#"{{"id":"{id}","name":"n","namespace":"ns","uid":"u","attempt":0,
+                 "labels":{{}},"annotations":{{}},"created_at_ns":0,"state":"NotReady",
+                 "pause_pid":{pause_pid}}}"#
+        );
+        serde_json::from_str(&json).expect("valid stopped sandbox json")
+    }
+
+    /// #438 regression: a NotReady sandbox whose pause is dead (because
+    /// StopPodSandbox was already called) must NOT be reaped as a phantom.
+    ///
+    /// The normal kubelet sequence is: StopPodSandbox → [kubectl logs works here]
+    /// → RemovePodSandbox.  If stale_sandbox_ids includes the NotReady sandbox,
+    /// list_pod_sandbox reaps it and its containers — ContainerStatus then returns
+    /// not_found and `kubectl logs` on a terminated pod fails.
+    #[test]
+    fn stopped_sandbox_with_dead_pause_is_not_reaped() {
+        // Sandbox explicitly stopped (state=NotReady); pause is gone.
+        let sandboxes = map(vec![stopped_sandbox("stopped", 1234)]);
+        let stale = stale_sandbox_ids(&sandboxes, |_pid| false); // all pids "dead"
+        assert!(
+            stale.is_empty(),
+            "a NotReady sandbox must not be reaped as a phantom (#438): {stale:?}"
+        );
+    }
+
+    /// #438: only Running sandboxes with a dead pause are phantoms.  A mix of
+    /// Running/NotReady sandboxes must reap exactly the Running-and-dead ones.
+    #[test]
+    fn only_running_sandboxes_with_dead_pause_are_reaped() {
+        let sandboxes = map(vec![
+            sandbox("running-live", 1001),         // Running, pause alive → keep
+            sandbox("running-dead", 1002),         // Running, pause dead → reap
+            stopped_sandbox("stopped-dead", 1003), // NotReady, pause dead → keep
+        ]);
+        // pid 1001 alive; 1002 and 1003 dead.
+        let mut stale = stale_sandbox_ids(&sandboxes, |pid| pid == 1001);
+        stale.sort();
+        assert_eq!(
+            stale,
+            vec!["running-dead".to_string()],
+            "only the Running sandbox with a dead pause must be reaped"
+        );
     }
 
     /// #347 follow-up: reaping a dead-pause "phantom" sandbox must drop it from the

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -190,7 +190,33 @@ pub struct CriPortMapping {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SandboxState {
     Running,
+    /// The sandbox has been explicitly stopped via `StopPodSandbox`.
+    ///
+    /// **Invariant**: this variant is set in exactly ONE place —
+    /// `stop_pod_sandbox` in `runtime.rs`.  Nothing else must write it.
+    /// Phantom-detection (`stale_sandbox_ids`) relies on this: a sandbox
+    /// in this state has a dead pause *by design*, so the missing pause is
+    /// not evidence of an unexpected crash.  If you add another code path
+    /// that sets `NotReady`, update `CriSandbox::is_explicitly_stopped` and
+    /// `stale_sandbox_ids` to match.
     NotReady,
+}
+
+impl CriSandbox {
+    /// Returns `true` iff `stop_pod_sandbox` has been called for this sandbox.
+    ///
+    /// The phantom-reaping logic uses this to distinguish between two cases
+    /// that look identical at the pause-liveness level:
+    ///
+    /// * `false` (state == Running, pause dead) → unexpected crash → phantom → reap
+    /// * `true`  (state == NotReady, pause dead) → explicit stop → waiting for
+    ///   `remove_pod_sandbox` → do NOT reap (#438)
+    ///
+    /// The single source of truth for the mapping is `SandboxState::NotReady`;
+    /// see the invariant doc on that variant before adding new callers.
+    pub fn is_explicitly_stopped(&self) -> bool {
+        self.state == SandboxState::NotReady
+    }
 }
 
 // ── CRI container metadata ───────────────────────────────────────────────────
@@ -487,12 +513,13 @@ pub(crate) fn stale_sandbox_ids<F: Fn(i32) -> bool>(
 ) -> Vec<String> {
     sandboxes
         .values()
-        // Only reap Running sandboxes whose pause has died unexpectedly.
-        // A NotReady sandbox was explicitly stopped via StopPodSandbox and is
-        // waiting for RemovePodSandbox to clean it up. Reaping it early removes
-        // its containers from state, causing ContainerStatus to return not_found
-        // and breaking `kubectl logs` for terminated pods (#438).
-        .filter(|s| s.state == SandboxState::Running && s.pause_pid > 0 && !is_alive(s.pause_pid))
+        // Only reap sandboxes that were NOT explicitly stopped.  A sandbox
+        // where `is_explicitly_stopped()` returns true had its pause killed
+        // intentionally by `stop_pod_sandbox`; it must survive in state until
+        // `remove_pod_sandbox` is called, so that `ContainerStatus` can still
+        // return container records and `kubectl logs` works on terminated pods
+        // (#438).  See `CriSandbox::is_explicitly_stopped` for the invariant.
+        .filter(|s| !s.is_explicitly_stopped() && s.pause_pid > 0 && !is_alive(s.pause_pid))
         .map(|s| s.id.clone())
         .collect()
 }


### PR DESCRIPTION
## Summary

- `stale_sandbox_ids` now checks `s.state == SandboxState::Running` before treating a dead-pause sandbox as a phantom — a one-line change in `pelagos-cri/src/state.rs`
- Two new unit tests cover the regression and confirm the phantom-GC invariant is preserved
- `INTEGRATION_TESTS.md` updated

## Root cause

`stop_pod_sandbox` kills the pause process and marks the sandbox `NotReady`. `list_pod_sandbox` calls `stale_sandbox_ids`, which checked only `pause_pid > 0 && !is_alive(pause_pid)` — without inspecting sandbox state. A `NotReady` sandbox with a dead pause (the normal post-stop state) was indistinguishable from a phantom (unexpected crash), so it was reaped along with all its containers. `ContainerStatus` then returned `not_found`, and `kubectl logs` failed for any terminated pod.

## Fix

The distinction is now captured explicitly: phantoms are **Running** sandboxes whose pause died unexpectedly. A **NotReady** sandbox is one that was explicitly stopped and is waiting for `RemovePodSandbox`. The `#347` invariant is unchanged — unexpected crashes are still reaped at `list_pod_sandbox` time.

## Test plan

- [ ] `cargo test -p pelagos-cri` — 40 tests pass
- [ ] `cargo clippy -p pelagos-cri -- -D warnings` — clean
- [ ] Reproduce with `kubectl run log-test --image=busybox:1.36 --restart=Never --command -- echo hello && kubectl wait pod/log-test --for=jsonpath={.status.phase}=Succeeded && kubectl logs log-test` — must return the output instead of "unable to retrieve container logs"

Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)