### PR TITLE
fix(image): support uncompressed OCI layers in extract_layer (#441)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.47"
+version = "0.65.48"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1624,6 +1624,31 @@ then simulates a prior rootless-degraded layer (strips the suid bit + writes the
 rootless pull would permanently degrade setuid binaries for every root container reusing the
 layer.
 
+### `test_extract_layer_uncompressed`
+**Requires:** root
+
+Verifies the #441 fix: creates a synthetic **uncompressed** tar layer (no gzip wrapper),
+extracts it via `image::extract_layer()` with `application/vnd.oci.image.layer.v1.tar`,
+and asserts the file is present with correct content. Failure indicates the uncompressed-tar
+branch is missing or broken — images like `quay.io/kubevirt/virt-operator` that ship large
+uncompressed layers would fail to pull.
+
+### `test_extract_layer_unsupported_media_type`
+**Requires:** root
+
+Calls `image::extract_layer()` with an unrecognised mediaType
+(`application/vnd.oci.image.layer.v1.tar+zstd`) and asserts it returns an `io::Error`
+with kind `Unsupported` whose message names the bad type. Failure means unknown compression
+formats silently misparse blobs as gzip instead of surfacing a clear error.
+
+### `test_extract_layer_gzip_regression`
+**Requires:** root
+
+Extracts a gzip layer with the legacy Docker mediaType
+(`application/vnd.docker.image.rootfs.diff.tar.gzip`) to confirm the Docker variant is
+accepted alongside the OCI `+gzip` type. Failure indicates a regression in the
+compressed-layer branch after the #441 fix.
+
 ### `test_multi_layer_overlay_merge`
 **Requires:** root, rootfs
 

--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -477,7 +477,7 @@ async fn pull_image(
             if is_wasm {
                 image::extract_wasm_layer(layer_digest, tmp.path())?;
             } else {
-                extract_layer(layer_digest, tmp.path())?;
+                extract_layer(layer_digest, tmp.path(), media_type)?;
             }
         }
         layer_digests.push(layer_digest.clone());
@@ -1165,6 +1165,13 @@ pub fn cmd_image_load(
                 .get("digest")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| format!("layer {}: missing 'digest'", i))?;
+            // Extract mediaType from the layer descriptor if present. Fall back to ""
+            // (empty string), which extract_layer() treats as gzip for backward compat
+            // with OCI tar archives that predate the mediaType annotation.
+            let media_type = layer_desc
+                .get("mediaType")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
             let layer_hex = layer_digest.strip_prefix("sha256:").unwrap_or(layer_digest);
             let layer_key = format!("blobs/sha256/{}", layer_hex);
             let layer_data = entries
@@ -1175,7 +1182,7 @@ pub fn cmd_image_load(
                 let mut tmp = tempfile::NamedTempFile::new()?;
                 tmp.write_all(layer_data)?;
                 tmp.flush()?;
-                extract_layer(layer_digest, tmp.path())?;
+                extract_layer(layer_digest, tmp.path(), media_type)?;
             }
             layer_digests.push(layer_digest.to_string());
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -310,14 +310,26 @@ pub fn load_oci_config(reference: &str) -> io::Result<String> {
     std::fs::read_to_string(oci_config_path(reference))
 }
 
-/// Extract a gzipped tar layer into the content-addressable layer store.
+/// Extract a tar layer into the content-addressable layer store, branching on `media_type`.
+///
+/// Supported media types:
+/// - `application/vnd.oci.image.layer.v1.tar+gzip` — gzip-compressed tar (OCI)
+/// - `application/vnd.docker.image.rootfs.diff.tar.gzip` — gzip-compressed tar (Docker)
+/// - `""` (empty string) — treated as gzip for backward compatibility with pre-mediaType callers
+/// - `application/vnd.oci.image.layer.v1.tar` — uncompressed tar (OCI, no `+gzip` suffix);
+///   used by images that ship large uncompressed layers (e.g. `quay.io/kubevirt/virt-operator`)
+///
+/// Any other media type returns an `io::Error` with kind `Unsupported`.
+///
+/// Future extension point: `application/vnd.oci.image.layer.v1.tar+zstd` (zstd-compressed)
+/// is not yet implemented; add a `zstd` dependency and a branch here when needed.
 ///
 /// Handles OCI whiteout files:
 /// - `.wh.<name>` → creates an overlayfs character device (0,0) named `<name>`.
 /// - `.wh..wh..opq` → sets the `trusted.overlay.opaque` xattr on the parent dir.
 ///
 /// Returns the path to the extracted layer directory.
-pub fn extract_layer(digest: &str, tar_gz_path: &Path) -> io::Result<PathBuf> {
+pub fn extract_layer(digest: &str, tar_path: &Path, media_type: &str) -> io::Result<PathBuf> {
     ensure_image_dirs()?;
     let rootless = crate::paths::is_rootless();
     let dest = layer_dir(digest);
@@ -344,9 +356,29 @@ pub fn extract_layer(digest: &str, tar_gz_path: &Path) -> io::Result<PathBuf> {
     }
     std::fs::create_dir_all(&partial)?;
 
-    let file = std::fs::File::open(tar_gz_path)?;
-    let decoder = flate2::read::GzDecoder::new(file);
-    let mut archive = tar::Archive::new(decoder);
+    let file = std::fs::File::open(tar_path)?;
+
+    // Branch on mediaType: gzip-compressed vs uncompressed tar.
+    // An empty string is treated as gzip for backward compat with callers that lack
+    // mediaType information (e.g. load_image from OCI tar archives without annotations).
+    let is_gzip = matches!(
+        media_type,
+        "" | "application/vnd.oci.image.layer.v1.tar+gzip"
+            | "application/vnd.docker.image.rootfs.diff.tar.gzip"
+    );
+    let is_plain_tar = media_type == "application/vnd.oci.image.layer.v1.tar";
+
+    let mut archive: tar::Archive<Box<dyn std::io::Read>> = if is_gzip {
+        let decoder = flate2::read::GzDecoder::new(file);
+        tar::Archive::new(Box::new(decoder))
+    } else if is_plain_tar {
+        tar::Archive::new(Box::new(file))
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("unsupported layer media type: {}", media_type),
+        ));
+    };
     archive.set_preserve_permissions(true);
     archive.set_overwrite(true);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8249,7 +8249,12 @@ mod images {
         let _ = std::fs::remove_file(&marker);
 
         // Root extract: suid preserved, no rootless marker.
-        let layer = pelagos::image::extract_layer(digest, &tar_gz).expect("extract");
+        let layer = pelagos::image::extract_layer(
+            digest,
+            &tar_gz,
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        )
+        .expect("extract");
         let suidtool = layer.join("usr/bin/suidtool");
         let mode1 = std::fs::metadata(&suidtool).unwrap().permissions().mode();
         assert_eq!(mode1 & 0o4000, 0o4000, "root extract must preserve suid");
@@ -8264,7 +8269,12 @@ mod images {
 
         // Root re-extract: the marker must trigger a full re-extraction that
         // restores the suid bit and clears the marker.
-        let layer2 = pelagos::image::extract_layer(digest, &tar_gz).expect("re-extract");
+        let layer2 = pelagos::image::extract_layer(
+            digest,
+            &tar_gz,
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        )
+        .expect("re-extract");
         let mode2 = std::fs::metadata(layer2.join("usr/bin/suidtool"))
             .unwrap()
             .permissions()
@@ -8355,7 +8365,11 @@ mod images {
         // Clean up any previous run.
         let _ = std::fs::remove_dir_all(&layer_path);
 
-        let result = image::extract_layer(digest, &tar_gz_path);
+        let result = image::extract_layer(
+            digest,
+            &tar_gz_path,
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        );
         assert!(
             result.is_ok(),
             "extract_layer should succeed: {:?}",
@@ -8380,6 +8394,181 @@ mod images {
         );
 
         // Clean up.
+        let _ = std::fs::remove_dir_all(&layer_path);
+    }
+
+    /// test_extract_layer_uncompressed
+    ///
+    /// Requires: root (for mknod whiteout devices in extract_layer).
+    ///
+    /// Creates a synthetic uncompressed tar layer (no gzip), extracts it via
+    /// `image::extract_layer()` with `application/vnd.oci.image.layer.v1.tar`,
+    /// and verifies the file is extracted correctly. Failure indicates the
+    /// uncompressed-layer branch introduced to fix issue #441 is broken.
+    #[test]
+    #[serial]
+    fn test_extract_layer_uncompressed() {
+        if !is_root() {
+            eprintln!("Skipping test_extract_layer_uncompressed: requires root");
+            return;
+        }
+
+        use pelagos::image;
+
+        // Build an uncompressed tar (no gzip wrapper).
+        let tmp_dir = tempfile::tempdir().expect("create tempdir");
+        let tar_path = tmp_dir.path().join("layer.tar");
+        {
+            let file = std::fs::File::create(&tar_path).expect("create tar");
+            let mut builder = tar::Builder::new(file);
+
+            let data = b"uncompressed content";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "plain.txt", &data[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let digest = "sha256:test_extract_layer_uncompressed_deadbeef";
+        let layer_path = image::layer_dir(digest);
+        let _ = std::fs::remove_dir_all(&layer_path);
+
+        let result =
+            image::extract_layer(digest, &tar_path, "application/vnd.oci.image.layer.v1.tar");
+        assert!(
+            result.is_ok(),
+            "extract_layer with uncompressed tar should succeed: {:?}",
+            result.err()
+        );
+        let extracted = result.unwrap();
+        assert!(
+            extracted.join("plain.txt").exists(),
+            "plain.txt should exist in extracted uncompressed layer"
+        );
+        assert_eq!(
+            std::fs::read_to_string(extracted.join("plain.txt")).unwrap(),
+            "uncompressed content"
+        );
+
+        let _ = std::fs::remove_dir_all(&layer_path);
+    }
+
+    /// test_extract_layer_unsupported_media_type
+    ///
+    /// Requires: root (ensure_image_dirs runs before mediaType check).
+    ///
+    /// Calls `image::extract_layer()` with an unrecognised mediaType and asserts
+    /// that it returns an `Unsupported` error rather than silently misinterpreting
+    /// the blob. Failure indicates the mediaType guard is missing or bypassed.
+    #[test]
+    #[serial]
+    fn test_extract_layer_unsupported_media_type() {
+        if !is_root() {
+            eprintln!("Skipping test_extract_layer_unsupported_media_type: requires root");
+            return;
+        }
+
+        use pelagos::image;
+
+        // Any file will do; the error must fire before we read content.
+        let tmp_dir = tempfile::tempdir().expect("create tempdir");
+        let dummy = tmp_dir.path().join("dummy");
+        std::fs::write(&dummy, b"not a tar").unwrap();
+
+        let digest = "sha256:test_extract_layer_unsupported_media_type_deadbeef";
+        let layer_path = image::layer_dir(digest);
+        let _ = std::fs::remove_dir_all(&layer_path);
+
+        let result = image::extract_layer(
+            digest,
+            &dummy,
+            "application/vnd.oci.image.layer.v1.tar+zstd",
+        );
+        assert!(
+            result.is_err(),
+            "extract_layer with unsupported media type must return an error"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::Unsupported,
+            "error kind must be Unsupported, got: {:?}",
+            err.kind()
+        );
+        assert!(
+            err.to_string()
+                .contains("application/vnd.oci.image.layer.v1.tar+zstd"),
+            "error message must name the bad media type: {}",
+            err
+        );
+
+        let _ = std::fs::remove_dir_all(&layer_path);
+    }
+
+    /// test_extract_layer_gzip_regression
+    ///
+    /// Requires: root (for mknod whiteout devices in extract_layer).
+    ///
+    /// Exercises the gzip path with the legacy Docker mediaType
+    /// (`application/vnd.docker.image.rootfs.diff.tar.gzip`) to confirm
+    /// both OCI and Docker gzip variants are accepted. Failure indicates
+    /// a regression in the compressed-layer branch after the #441 fix.
+    #[test]
+    #[serial]
+    fn test_extract_layer_gzip_regression() {
+        if !is_root() {
+            eprintln!("Skipping test_extract_layer_gzip_regression: requires root");
+            return;
+        }
+
+        use pelagos::image;
+
+        let tmp_dir = tempfile::tempdir().expect("create tempdir");
+        let tar_gz_path = tmp_dir.path().join("layer.tar.gz");
+        {
+            let file = std::fs::File::create(&tar_gz_path).expect("create tar.gz");
+            let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut builder = tar::Builder::new(gz);
+
+            let data = b"docker compat";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "docker-compat.txt", &data[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let digest = "sha256:test_extract_layer_gzip_regression_deadbeef";
+        let layer_path = image::layer_dir(digest);
+        let _ = std::fs::remove_dir_all(&layer_path);
+
+        let result = image::extract_layer(
+            digest,
+            &tar_gz_path,
+            "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        );
+        assert!(
+            result.is_ok(),
+            "extract_layer with Docker gzip media type should succeed: {:?}",
+            result.err()
+        );
+        let extracted = result.unwrap();
+        assert!(
+            extracted.join("docker-compat.txt").exists(),
+            "docker-compat.txt should exist"
+        );
+        assert_eq!(
+            std::fs::read_to_string(extracted.join("docker-compat.txt")).unwrap(),
+            "docker compat"
+        );
+
         let _ = std::fs::remove_dir_all(&layer_path);
     }
 
@@ -9248,7 +9437,12 @@ mod images {
         let _ = std::fs::remove_dir_all(&layer_path);
         let _ = std::fs::remove_file(&blob_path);
 
-        image::extract_layer(digest, tmp.path()).expect("extract_layer");
+        image::extract_layer(
+            digest,
+            tmp.path(),
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        )
+        .expect("extract_layer");
 
         assert!(
             layer_path.exists(),


### PR DESCRIPTION
## Summary

Fixes #441.

`extract_layer()` unconditionally wrapped every layer blob in `GzDecoder`, causing an "invalid gzip header" error for images that ship uncompressed tar layers (`application/vnd.oci.image.layer.v1.tar` — no `+gzip` suffix).

Discovered when pulling `quay.io/kubevirt/virt-operator:v1.8.4`, which carries three large (~125 MB total) uncompressed tar layers for QEMU binaries.

## Changes

- **`src/image.rs`** — add `media_type: &str` parameter to `extract_layer()`; branch before building the decoder:
  - `application/vnd.oci.image.layer.v1.tar+gzip`, `application/vnd.docker.image.rootfs.diff.tar.gzip`, or `""` (empty = legacy compat) → `GzDecoder` (existing behaviour preserved)
  - `application/vnd.oci.image.layer.v1.tar` — new: raw `Archive<File>`, no decompressor
  - anything else → `io::Error { kind: Unsupported }` naming the bad media type
  - Uses `Box<dyn Read>` to unify both decoder paths without duplicating the whiteout-processing loop
  - Notes `tar+zstd` as a future extension point in the doc comment
- **`src/cli/image.rs`** — update both call sites:
  - Registry pull path: passes the `media_type` already in scope
  - `pelagos image load` (OCI tar archive) path: reads `mediaType` from the layer descriptor JSON, falling back to `""` for archives without the annotation (backward compat)
- **`tests/integration_tests.rs`** — three new tests: `test_extract_layer_uncompressed`, `test_extract_layer_unsupported_media_type`, `test_extract_layer_gzip_regression`; all existing `extract_layer` call sites updated with explicit media type strings
- **`docs/INTEGRATION_TESTS.md`** — entries for the three new tests

## Test plan

- [ ] `cargo test --lib` — 392 unit tests pass
- [ ] `sudo -E cargo test --test integration_tests images::test_extract_layer` — original gzip test passes
- [ ] `sudo -E cargo test --test integration_tests images::test_extract_layer_uncompressed` — new uncompressed test passes
- [ ] `sudo -E cargo test --test integration_tests images::test_extract_layer_unsupported_media_type` — unsupported type returns `Unsupported` error
- [ ] `sudo -E cargo test --test integration_tests images::test_extract_layer_gzip_regression` — Docker gzip media type still accepted
- [ ] `sudo -E cargo test --test integration_tests images::test_extract_layer_reextracts_rootless_degraded_layer` — #384 regression test still passes
- [ ] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)