### PR TITLE
chore(release): v0.65.49 — version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.48"
+version = "0.65.49"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ h2 = { path = "vendor/h2" }
 
 [package]
 name = "pelagos"
-version = "0.65.48"
+version = "0.65.49"
 edition = "2021"
 rust-version = "1.76"
 description = "Fast Linux container runtime — OCI-compatible, namespaces, cgroups v2, seccomp, networking, image management"


### PR DESCRIPTION
Bumps Cargo.toml to 0.65.49. The fix (uncompressed OCI layer support, #441) already shipped in the v0.65.49 tag but the version string was not bumped before tagging.