### PR TITLE
fix(container): /sys/fs/cgroup in privileged containers (#444) + auto-create missing HostPath source dirs (#445)

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -3271,7 +3271,23 @@ impl Command {
             .selinux_label
             .clone()
             .filter(|_| crate::mac::is_selinux_enabled());
-        let bind_mounts = self.bind_mounts.clone();
+        let mut bind_mounts = self.bind_mounts.clone();
+        // #444: privileged containers need /sys/fs/cgroup for cgroup detection
+        // (e.g. runc's IsCgroup2UnifiedMode). Inject a recursive bind mount of
+        // the host's cgroup hierarchy before pivot_root so it survives into the
+        // container — the same thing containerd/CRI-O do automatically.
+        if self.privileged && std::path::Path::new("/sys/fs/cgroup").exists() {
+            let cgroup_target = std::path::PathBuf::from("/sys/fs/cgroup");
+            if !bind_mounts.iter().any(|bm| bm.target == cgroup_target) {
+                bind_mounts.push(BindMount {
+                    source: std::path::PathBuf::from("/sys/fs/cgroup"),
+                    target: cgroup_target,
+                    readonly: false,
+                    recursive_readonly: false,
+                    propagation: MountPropagation::Private,
+                });
+            }
+        }
         let tmpfs_mounts = self.tmpfs_mounts.clone();
         let kernel_mounts = self.kernel_mounts.clone();
         let propagation_mounts = self.propagation_mounts.clone();
@@ -4839,6 +4855,14 @@ impl Command {
                         let host_target = resolve_mount_target_in_root(effective_root, &bm.target);
                         // Linux requires the mount target to exist and be the same type
                         // (file or directory) as the source.
+                        // #445: if the source doesn't exist, create it as a directory.
+                        // containerd does the same for HostPath volumes with type="" so
+                        // workloads that rely on the runtime creating missing host dirs
+                        // (e.g. KubeVirt's virt-handler) work without manual pre-creation.
+                        if !bm.source.exists() {
+                            std::fs::create_dir_all(&bm.source)
+                                .map_err(|e| pre_exec_err("bind mount mkdir source", e))?;
+                        }
                         if bm.source.is_dir() {
                             std::fs::create_dir_all(&host_target)
                                 .map_err(|e| pre_exec_err("bind mount mkdir", e))?;
@@ -6230,7 +6254,20 @@ impl Command {
             .selinux_label
             .clone()
             .filter(|_| crate::mac::is_selinux_enabled());
-        let bind_mounts = self.bind_mounts.clone();
+        let mut bind_mounts = self.bind_mounts.clone();
+        // #444: same cgroup inject as in spawn() — see comment there.
+        if self.privileged && std::path::Path::new("/sys/fs/cgroup").exists() {
+            let cgroup_target = std::path::PathBuf::from("/sys/fs/cgroup");
+            if !bind_mounts.iter().any(|bm| bm.target == cgroup_target) {
+                bind_mounts.push(BindMount {
+                    source: std::path::PathBuf::from("/sys/fs/cgroup"),
+                    target: cgroup_target,
+                    readonly: false,
+                    recursive_readonly: false,
+                    propagation: MountPropagation::Private,
+                });
+            }
+        }
         let tmpfs_mounts = self.tmpfs_mounts.clone();
         let kernel_mounts = self.kernel_mounts.clone();
         let propagation_mounts = self.propagation_mounts.clone();
@@ -7544,6 +7581,11 @@ impl Command {
                         // Resolve symlinked parents in the image rootfs (e.g.
                         // /var/run -> /run) before binding. See issue #334.
                         let host_target = resolve_mount_target_in_root(effective_root, &bm.target);
+                        // #445: create missing source as a directory (containerd compat).
+                        if !bm.source.exists() {
+                            std::fs::create_dir_all(&bm.source)
+                                .map_err(|e| pre_exec_err("bind mount mkdir source", e))?;
+                        }
                         if bm.source.is_dir() {
                             std::fs::create_dir_all(&host_target)
                                 .map_err(|e| pre_exec_err("bind mount mkdir", e))?;


### PR DESCRIPTION
## Summary

Two CRI compatibility fixes that unblock KubeVirt's `virt-handler` DaemonSet on Pelagos.

### #444 — privileged containers cannot access `/sys/fs/cgroup`

containerd and CRI-O bind-mount the host's `/sys/fs/cgroup` recursively into privileged containers. Pelagos did not, so any workload using runc's cgroup detection (`IsCgroup2UnifiedMode`) panicked at startup:

```
panic: cannot statfs cgroup root: no such file or directory
```

**Fix**: before `pivot_root`, inject `/sys/fs/cgroup` as an extra `BindMount` when `privileged=true`. The existing bind_mounts loop already uses `MS_BIND|MS_REC`, so the full cgroup hierarchy is carried into the container. Applied in both `spawn()` and `spawn_interactive()`. Skips injection if the caller already mounted `/sys/fs/cgroup` explicitly.

### #445 — missing HostPath source dir causes ENOENT instead of auto-create

When a HostPath volume with `type=""` is mounted and the source path does not exist on the host, Pelagos failed to spawn the container with ENOENT (`Failed to spawn process: No such file or directory`). containerd silently creates the directory in this case. Workloads like KubeVirt's `virt-handler` rely on this to bootstrap host-side state dirs on first run.

**Fix**: before the `is_dir()` target-type check, create the source path as a directory if it does not exist. Applied in both `spawn()` and `spawn_interactive()`.

## Test plan

- [x] `cargo build` clean
- [x] `pelagos run --privileged --rm <image> stat /sys/fs/cgroup` — now succeeds
- [x] `pelagos run --volume /nonexistent/path:/mnt/test --rm alpine echo ok` — now succeeds and creates the source dir