### PR TITLE
fix(cri): pass device plugin device allocations into containers (#449)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1689,6 +1689,21 @@ impl RuntimeService for RuntimeSvc {
                 .get("io.kubernetes.cri.container-type")
                 .map(|v| v == "sidecar_container")
                 .unwrap_or(false),
+            // Device plugin allocations from ContainerConfig.devices (#449).
+            // The kubelet populates this from device plugin AllocateResponse.DeviceSpecs.
+            devices: config
+                .devices
+                .iter()
+                .map(|d| state::CriDevice {
+                    host_path: d.host_path.clone(),
+                    container_path: if d.container_path.is_empty() {
+                        d.host_path.clone()
+                    } else {
+                        d.container_path.clone()
+                    },
+                    permissions: d.permissions.clone(),
+                })
+                .collect(),
         };
 
         {
@@ -2038,6 +2053,23 @@ impl RuntimeService for RuntimeSvc {
         if !container.selinux_label.is_empty() {
             args.push("--selinux-label".into());
             args.push(container.selinux_label.clone());
+        }
+
+        // Device plugin device allocations (ContainerConfig.devices).
+        // The kubelet populates this from device plugin AllocateResponse.DeviceSpecs;
+        // each entry has a host_path, container_path, and permissions string.
+        // Pass them as --device host:container so pelagos mknod's the node inside
+        // the container's /dev and records it in the cgroup device allowlist (#449).
+        for dev in &container.devices {
+            if !dev.host_path.is_empty() {
+                let container_path = if dev.container_path.is_empty() {
+                    &dev.host_path
+                } else {
+                    &dev.container_path
+                };
+                args.push("--device".into());
+                args.push(format!("{}:{}", dev.host_path, container_path));
+            }
         }
 
         // `--` stops clap flag parsing so that container args beginning with `-`

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -365,6 +365,19 @@ pub struct CriContainer {
     /// containers without re-parsing the labels map on every call (#437).
     #[serde(default)]
     pub is_sidecar: bool,
+    /// Device plugin device allocations from ContainerConfig.devices.
+    /// Each entry is "host_path:container_path" (container_path may equal host_path).
+    #[serde(default)]
+    pub devices: Vec<CriDevice>,
+}
+
+/// A host device to expose inside the container, derived from the CRI Device proto.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CriDevice {
+    pub host_path: String,
+    pub container_path: String,
+    /// Cgroup permissions string ("mrw", "r", etc.).
+    pub permissions: String,
 }
 
 fn default_oom_score_unset() -> i32 {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -219,6 +219,10 @@ pub struct SpawnConfig {
     /// tmpfs mounts as "path" or "path:options" strings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tmpfs: Vec<String>,
+    /// Host device files to expose inside the container, as "host_path[:/container_path]" strings.
+    /// Device type, major/minor, and mode are stat'd from the host at spawn time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub device: Vec<String>,
     /// When true, the container runs in the host PID namespace (no CLONE_NEWPID).
     /// Saved from `--no-pid-ns`; restored by `pelagos start`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -30,7 +30,7 @@ use super::{
     parse_user_in_rootfs, rootfs_path, write_state, ContainerState, ContainerStatus, HealthConfig,
     HealthStatus, SpawnConfig,
 };
-use pelagos::container::{Capability, Command, Namespace, Stdio, Volume};
+use pelagos::container::{self, Capability, Command, Namespace, Stdio, Volume};
 use pelagos::network::NetworkMode;
 use pelagos::wasm::WasmRuntime;
 use std::io::{self, Read, Write};
@@ -111,6 +111,14 @@ pub struct RunArgs {
     /// Read-only bind mount /host:/container (repeatable)
     #[clap(long = "bind-ro")]
     pub bind_ro: Vec<String>,
+
+    /// Expose a host device inside the container.
+    /// Format: /host/path[:/container/path]
+    /// The host file is stat'd to obtain device type, major/minor, and mode.
+    /// Defaults container_path to host_path when omitted.
+    /// (repeatable)
+    #[clap(long = "device")]
+    pub device: Vec<String>,
 
     /// tmpfs mount `/path[:options]` (repeatable)
     #[clap(long = "tmpfs")]
@@ -534,6 +542,7 @@ fn build_spawn_config(args: &RunArgs, rootfs_label: &str, exe_and_args: &[String
         no_nat: args.no_nat,
         labels: args.label.clone(),
         tmpfs: args.tmpfs.clone(),
+        device: args.device.clone(),
         no_pid_ns: args.no_pid_ns,
         no_ipc_ns: args.no_ipc_ns,
         privileged: args.privileged,
@@ -998,6 +1007,9 @@ fn apply_cli_options(
         let (src, tgt) = split_mount_spec(b, "--bind-ro")?;
         cmd = cmd.with_bind_mount_ro(src, tgt);
     }
+    for d in &args.device {
+        cmd = add_device(cmd, d)?;
+    }
     for t in &args.tmpfs {
         let (path, opts) = t.split_once(':').unwrap_or((t.as_str(), ""));
         cmd = cmd.with_tmpfs(path, opts);
@@ -1268,6 +1280,43 @@ fn split_mount_spec<'a>(
 ) -> Result<(&'a str, &'a str), Box<dyn std::error::Error>> {
     s.split_once(':')
         .ok_or_else(|| format!("invalid {} '{}': expected /host:/container", flag, s).into())
+}
+
+/// Parse `--device /host/path[:/container/path]`, stat the host file, and call
+/// `cmd.with_device()` with the discovered properties.
+///
+/// Works for character devices (e.g. `/dev/kvm`, `/dev/net/tun`, `/dev/vhost-net`).
+/// The container_path defaults to host_path when omitted.
+fn add_device(
+    cmd: Command,
+    spec: &str,
+) -> Result<Command, Box<dyn std::error::Error>> {
+    let (host_path, container_path) = if let Some((h, c)) = spec.split_once(':') {
+        (h, c)
+    } else {
+        (spec, spec)
+    };
+    let st = nix::sys::stat::stat(host_path)
+        .map_err(|e| format!("--device {}: {}", host_path, e))?;
+    let kind = if nix::sys::stat::SFlag::from_bits_truncate(st.st_mode as _)
+        .contains(nix::sys::stat::SFlag::S_IFBLK)
+    {
+        'b'
+    } else {
+        'c' // default to character device
+    };
+    let major = nix::sys::stat::major(st.st_rdev);
+    let minor = nix::sys::stat::minor(st.st_rdev);
+    let mode = st.st_mode & 0o777;
+    Ok(cmd.with_device(container::DeviceNode {
+        path: std::path::PathBuf::from(container_path),
+        kind,
+        major: major as u64,
+        minor: minor as u64,
+        mode,
+        uid: st.st_uid,
+        gid: st.st_gid,
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -127,6 +127,7 @@ fn spawn_config_to_run_args(
         bind: sc.bind,
         bind_ro: sc.bind_ro,
         tmpfs: sc.tmpfs,
+        device: sc.device,
         read_only: sc.read_only,
         env: sc.env,
         env_file: None,


### PR DESCRIPTION
Fixes #449.

## Summary

`ContainerConfig.devices` (the CRI field populated by device plugins via kubelet) was silently dropped — there was no `--device` flag in `pelagos run` and no storage for devices in `CriContainer`. This left KubeVirt VMs stuck in `Scheduled` phase because virt-handler could not find `/dev/kvm` inside the compute container.

## Changes

| File | Change |
|------|--------|
| `src/cli/mod.rs` | Add `device: Vec<String>` to `SpawnConfig` (persisted for restart) |
| `src/cli/run.rs` | Add `--device /host[:/container]` flag; `stat()` the host path to get device type + major/minor + mode; call `with_device(DeviceNode{...})` |
| `src/cli/start.rs` | Propagate `SpawnConfig.device` on container restart |
| `pelagos-cri/src/state.rs` | Add `CriDevice` struct and `devices: Vec<CriDevice>` field to `CriContainer` |
| `pelagos-cri/src/runtime.rs` | Extract `ContainerConfig.devices` at `create_container` time; emit `--device host:container` at `run_container` time |

## Reproducer

KubeVirt VMI with `devices.kubevirt.io/kvm: 1` (compute container). Before this fix:
```
Warning  SyncFailed  virt-handler  failed opening kvm for path root:
  /proc/<pid>/root, relative: /dev/kvm: no such file or directory
```

After this fix the device node is created in `/dev` inside the container and virt-handler can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)