### PR TITLE
fix(container): cgroupfs invisible when sysfs shadows pre-pivot bind (#455)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5641,3 +5641,30 @@ matters:** this is the specific file path that libvirt's `virHostCPUGetOnlineBit
 via `open()` to enumerate online CPUs for vCPU affinity mapping before QEMU exec. Even
 if sysfs is mounted, a kernel that exposes fewer sub-paths than expected would cause the
 same ENOENT failure. This test pins the exact failure path from the KubeVirt strace.
+
+## `issue_455_cgroupfs_sysfs_order::test_cgroupfs_visible_with_mount_sys`
+**Requires root.** Launches an image-layer container (`with_image_layers`), runs `stat
+/sys/fs/cgroup` inside it, and asserts the command succeeds. **Why it matters:** when
+`mount_sys=true`, a fresh sysfs is mounted at `/sys` after `pivot_root`. Before #455 the
+cgroupfs was bind-mounted into `bind_mounts` before `pivot_root`, so after sysfs mounted at
+`/sys` the bind was shadowed — path traversal entered sysfs and found its own virtual
+`fs/cgroup/` directory instead of the real cgroupfs. The fix uses a temporary staging bind
+at `/.cg_tmp` inside the container root (before `pivot_root`) and then `MS_MOVE`s it onto
+`/sys/fs/cgroup` after sysfs is mounted. Failure means tools using cgroupfs inside
+image-layer containers (runc's `IsCgroup2UnifiedMode`, Kubernetes cgroup-aware workloads)
+break silently.
+
+## `issue_455_cgroupfs_sysfs_order::test_cgroupfs_readonly_in_nonprivileged_container`
+**Requires root.** Spawns a non-privileged image-layer container and checks `/proc/mounts`
+to confirm `/sys/fs/cgroup` is present with the `ro` mount option. **Why it matters:**
+the staging + MS_MOVE approach must preserve the RO/RW distinction — after the move the
+RO remount must still be applied correctly. Failure here means either cgroupfs is
+completely absent (wrong staging) or the RO remount was skipped (security regression: a
+non-privileged container can write cgroup.procs on the host).
+
+## `issue_455_cgroupfs_sysfs_order::test_cgroupfs_readwrite_in_privileged_container`
+**Requires root.** Spawns a privileged image-layer container and checks `/proc/mounts` to
+confirm `/sys/fs/cgroup` is present WITHOUT the `ro` option. **Why it matters:** companion
+to the above — confirms that privileged containers still receive a read-write cgroupfs
+(needed by KubeVirt `virt-handler` and device plugin accounting). Failure here means the
+MS_MOVE path is applying the RO remount unconditionally.

--- a/src/container.rs
+++ b/src/container.rs
@@ -3274,15 +3274,27 @@ impl Command {
             .clone()
             .filter(|_| crate::mac::is_selinux_enabled());
         let mut bind_mounts = self.bind_mounts.clone();
-        // #444 / #452: inject /sys/fs/cgroup so statfs("/sys/fs/cgroup") works inside
+        // #444 / #452 / #455: inject /sys/fs/cgroup so statfs("/sys/fs/cgroup") works inside
         // the container (needed by runc's IsCgroup2UnifiedMode and virt-launcher's
         // GetPodCPUSet). Privileged containers get RW; non-privileged get READ-ONLY
         // so libvirt/virtqemud sees EROFS when attempting to write cgroup.procs and
         // skips host-level cgroup placement gracefully (#453).
         // Skipped when CAP_SYS_ADMIN is absent (nested/in-pod builds): inside a
         // user namespace you cannot bind-mount the host cgroup hierarchy — EPERM.
+        //
+        // When mount_sys is true we mount a fresh sysfs at /sys AFTER pivot_root.
+        // A pre-pivot cgroupfs bind at /sys/fs/cgroup ends up shadowed by sysfs
+        // (path traversal through /sys enters sysfs and finds sysfs's own fs/cgroup/
+        // virtual node instead of the cgroupfs mount).  In that case we defer the
+        // bind to post-sysfs, using an O_PATH fd opened just before pivot_root to
+        // survive the root switch (#455).
+        let inject_cgroup_after_sysfs = self.chroot_dir.is_some()
+            && !lacks_sys_admin
+            && self.mount_sys
+            && std::path::Path::new("/sys/fs/cgroup").exists();
         if self.chroot_dir.is_some()
             && !lacks_sys_admin
+            && !self.mount_sys
             && std::path::Path::new("/sys/fs/cgroup").exists()
         {
             let cgroup_target = std::path::PathBuf::from("/sys/fs/cgroup");
@@ -4545,6 +4557,11 @@ impl Command {
                 // a fresh procfs mount is refused after the pivot (see the
                 // proc-mount fallback below).
                 let mut proc_stashed = false;
+                // #455: true when we successfully bind-mounted the host cgroupfs to
+                // <effective_root>/.cg_tmp before pivot_root.  After pivot_root the
+                // bind survives as /.cg_tmp; after sysfs it is MS_MOVE'd onto
+                // /sys/fs/cgroup so path traversal through sysfs finds it correctly.
+                let mut cgroup_staged = false;
 
                 // Step 4: Change root if specified
                 if let Some(ref dir) = chroot_dir {
@@ -5151,6 +5168,37 @@ impl Command {
                     // mount namespace root and detaches the old root.
                     // Fuse overlay (rootless) uses the same path — effective_root
                     // is the merged dir, which is in our private mount namespace.
+
+                    // #455: stage cgroupfs at <effective_root>/.cg_tmp before
+                    // pivot_root.  After pivot_root this appears as /.cg_tmp and
+                    // can be MS_MOVE'd to /sys/fs/cgroup after sysfs is mounted.
+                    // (O_PATH fd approach fails: after MNT_DETACH the host cgroupfs
+                    // is no longer in the namespace mount table so bind-from-fd
+                    // returns EINVAL.)
+                    if inject_cgroup_after_sysfs
+                        && std::path::Path::new("/sys/fs/cgroup").exists()
+                    {
+                        let tmp = effective_root.join(".cg_tmp");
+                        let _ = std::fs::create_dir_all(&tmp);
+                        let src_c = CString::new("/sys/fs/cgroup").unwrap();
+                        let tgt_c =
+                            CString::new(tmp.as_os_str().as_bytes()).unwrap();
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        cgroup_staged = r == 0;
+                        if !cgroup_staged {
+                            log::debug!(
+                                "cgroupfs staging bind failed: {}",
+                                io::Error::last_os_error()
+                            );
+                        }
+                    }
+
                     let put_old_name = pivot_put_old_name.as_deref().unwrap_or(".pivot_root_old");
                     do_pivot_root(effective_root, put_old_name)?;
 
@@ -5258,6 +5306,39 @@ impl Command {
                     );
                     if result != 0 && !is_rootless && !lacks_sys_admin {
                         return Err(pre_exec_err("mount sysfs", io::Error::last_os_error()));
+                    }
+
+                    // #455: MS_MOVE the staged cgroupfs from /.cg_tmp onto
+                    // /sys/fs/cgroup inside the freshly-mounted sysfs so path
+                    // traversal through sysfs reaches the real cgroupfs, not sysfs's
+                    // own virtual fs/cgroup/ directory.
+                    if cgroup_staged {
+                        let _ = std::fs::create_dir_all("/sys/fs/cgroup");
+                        let cg_src = CString::new("/.cg_tmp").unwrap();
+                        let cg_tgt = CString::new("/sys/fs/cgroup").unwrap();
+                        let r = libc::mount(
+                            cg_src.as_ptr(),
+                            cg_tgt.as_ptr(),
+                            ptr::null(),
+                            libc::MS_MOVE,
+                            ptr::null(),
+                        );
+                        if r == 0 && !privileged {
+                            libc::mount(
+                                ptr::null(),
+                                cg_tgt.as_ptr(),
+                                ptr::null(),
+                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                ptr::null(),
+                            );
+                        }
+                        libc::rmdir(cg_src.as_ptr());
+                        if r != 0 && !is_rootless && !lacks_sys_admin {
+                            return Err(pre_exec_err(
+                                "move cgroupfs",
+                                io::Error::last_os_error(),
+                            ));
+                        }
                     }
                 }
 
@@ -6437,11 +6518,17 @@ impl Command {
             .clone()
             .filter(|_| crate::mac::is_selinux_enabled());
         let mut bind_mounts = self.bind_mounts.clone();
-        // #444 / #452 / #453: same cgroup inject as in spawn() — see comment there.
+        // #444 / #452 / #453 / #455: same cgroup inject as in spawn() — see comment there.
         // Privileged = RW, non-privileged = RO to prevent libvirt cgroup write attempts.
         // Skipped when CAP_SYS_ADMIN is absent (nested/in-pod builds): EPERM inside user ns.
+        // When mount_sys is true, cgroupfs is deferred to post-sysfs via O_PATH fd (#455).
+        let inject_cgroup_after_sysfs = self.chroot_dir.is_some()
+            && !lacks_sys_admin
+            && self.mount_sys
+            && std::path::Path::new("/sys/fs/cgroup").exists();
         if self.chroot_dir.is_some()
             && !lacks_sys_admin
+            && !self.mount_sys
             && std::path::Path::new("/sys/fs/cgroup").exists()
         {
             let cgroup_target = std::path::PathBuf::from("/sys/fs/cgroup");
@@ -7466,6 +7553,9 @@ impl Command {
                 // #426: set when we stash a recursive bind of the parent's /proc
                 // inside the new root before pivot_root (see the other spawn path).
                 let mut proc_stashed = false;
+                // #455: true when cgroupfs was staged at <effective_root>/.cg_tmp
+                // before pivot_root (see the other spawn path for full explanation).
+                let mut cgroup_staged = false;
 
                 if let Some(ref dir) = chroot_dir {
                     use std::os::unix::ffi::OsStrExt;
@@ -8012,6 +8102,33 @@ impl Command {
                     // mount namespace root and detaches the old root.
                     // Fuse overlay (rootless) uses the same path — effective_root
                     // is the merged dir, which is in our private mount namespace.
+
+                    // #455: stage cgroupfs at <effective_root>/.cg_tmp before
+                    // pivot_root — mirrors the spawn() path (see comment there).
+                    if inject_cgroup_after_sysfs
+                        && std::path::Path::new("/sys/fs/cgroup").exists()
+                    {
+                        let tmp = effective_root.join(".cg_tmp");
+                        let _ = std::fs::create_dir_all(&tmp);
+                        let src_c = CString::new("/sys/fs/cgroup").unwrap();
+                        let tgt_c =
+                            CString::new(tmp.as_os_str().as_bytes()).unwrap();
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        cgroup_staged = r == 0;
+                        if !cgroup_staged {
+                            log::debug!(
+                                "cgroupfs staging bind failed: {}",
+                                io::Error::last_os_error()
+                            );
+                        }
+                    }
+
                     let put_old_name = pivot_put_old_name.as_deref().unwrap_or(".pivot_root_old");
                     do_pivot_root(effective_root, put_old_name)?;
                     let cwd = container_cwd
@@ -8103,6 +8220,37 @@ impl Command {
                     );
                     if result != 0 && !is_rootless && !lacks_sys_admin {
                         return Err(pre_exec_err("mount sysfs", io::Error::last_os_error()));
+                    }
+
+                    // #455: MS_MOVE staged cgroupfs from /.cg_tmp onto
+                    // /sys/fs/cgroup inside sysfs — mirrors the spawn() path.
+                    if cgroup_staged {
+                        let _ = std::fs::create_dir_all("/sys/fs/cgroup");
+                        let cg_src = CString::new("/.cg_tmp").unwrap();
+                        let cg_tgt = CString::new("/sys/fs/cgroup").unwrap();
+                        let r = libc::mount(
+                            cg_src.as_ptr(),
+                            cg_tgt.as_ptr(),
+                            ptr::null(),
+                            libc::MS_MOVE,
+                            ptr::null(),
+                        );
+                        if r == 0 && !privileged {
+                            libc::mount(
+                                ptr::null(),
+                                cg_tgt.as_ptr(),
+                                ptr::null(),
+                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                ptr::null(),
+                            );
+                        }
+                        libc::rmdir(cg_src.as_ptr());
+                        if r != 0 && !is_rootless && !lacks_sys_admin {
+                            return Err(pre_exec_err(
+                                "move cgroupfs",
+                                io::Error::last_os_error(),
+                            ));
+                        }
                     }
                 }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -5175,14 +5175,12 @@ impl Command {
                     // (O_PATH fd approach fails: after MNT_DETACH the host cgroupfs
                     // is no longer in the namespace mount table so bind-from-fd
                     // returns EINVAL.)
-                    if inject_cgroup_after_sysfs
-                        && std::path::Path::new("/sys/fs/cgroup").exists()
+                    if inject_cgroup_after_sysfs && std::path::Path::new("/sys/fs/cgroup").exists()
                     {
                         let tmp = effective_root.join(".cg_tmp");
                         let _ = std::fs::create_dir_all(&tmp);
                         let src_c = CString::new("/sys/fs/cgroup").unwrap();
-                        let tgt_c =
-                            CString::new(tmp.as_os_str().as_bytes()).unwrap();
+                        let tgt_c = CString::new(tmp.as_os_str().as_bytes()).unwrap();
                         let r = libc::mount(
                             src_c.as_ptr(),
                             tgt_c.as_ptr(),
@@ -5334,10 +5332,7 @@ impl Command {
                         }
                         libc::rmdir(cg_src.as_ptr());
                         if r != 0 && !is_rootless && !lacks_sys_admin {
-                            return Err(pre_exec_err(
-                                "move cgroupfs",
-                                io::Error::last_os_error(),
-                            ));
+                            return Err(pre_exec_err("move cgroupfs", io::Error::last_os_error()));
                         }
                     }
                 }
@@ -8105,14 +8100,12 @@ impl Command {
 
                     // #455: stage cgroupfs at <effective_root>/.cg_tmp before
                     // pivot_root — mirrors the spawn() path (see comment there).
-                    if inject_cgroup_after_sysfs
-                        && std::path::Path::new("/sys/fs/cgroup").exists()
+                    if inject_cgroup_after_sysfs && std::path::Path::new("/sys/fs/cgroup").exists()
                     {
                         let tmp = effective_root.join(".cg_tmp");
                         let _ = std::fs::create_dir_all(&tmp);
                         let src_c = CString::new("/sys/fs/cgroup").unwrap();
-                        let tgt_c =
-                            CString::new(tmp.as_os_str().as_bytes()).unwrap();
+                        let tgt_c = CString::new(tmp.as_os_str().as_bytes()).unwrap();
                         let r = libc::mount(
                             src_c.as_ptr(),
                             tgt_c.as_ptr(),
@@ -8246,10 +8239,7 @@ impl Command {
                         }
                         libc::rmdir(cg_src.as_ptr());
                         if r != 0 && !is_rootless && !lacks_sys_admin {
-                            return Err(pre_exec_err(
-                                "move cgroupfs",
-                                io::Error::last_os_error(),
-                            ));
+                            return Err(pre_exec_err("move cgroupfs", io::Error::last_os_error()));
                         }
                     }
                 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -30486,9 +30486,7 @@ mod issue_455_cgroupfs_sysfs_order {
     #[test]
     fn test_cgroupfs_readonly_in_nonprivileged_container() {
         if !is_root() {
-            eprintln!(
-                "Skipping test_cgroupfs_readonly_in_nonprivileged_container: requires root"
-            );
+            eprintln!("Skipping test_cgroupfs_readonly_in_nonprivileged_container: requires root");
             return;
         }
         let Some(rootfs) = ensure_alpine() else {
@@ -30535,9 +30533,7 @@ mod issue_455_cgroupfs_sysfs_order {
     #[test]
     fn test_cgroupfs_readwrite_in_privileged_container() {
         if !is_root() {
-            eprintln!(
-                "Skipping test_cgroupfs_readwrite_in_privileged_container: requires root"
-            );
+            eprintln!("Skipping test_cgroupfs_readwrite_in_privileged_container: requires root");
             return;
         }
         let Some(rootfs) = ensure_alpine() else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -30437,3 +30437,146 @@ mod issue_452_sysfs_mount {
         );
     }
 }
+
+mod issue_455_cgroupfs_sysfs_order {
+    use super::*;
+
+    fn ensure_alpine() -> Option<PathBuf> {
+        get_test_rootfs()
+    }
+
+    /// /sys/fs/cgroup must be reachable inside image-layer containers (#455).
+    /// When mount_sys=true, a fresh sysfs is mounted at /sys after pivot_root,
+    /// which used to shadow the pre-pivot cgroupfs bind.  The O_PATH fd fix
+    /// re-attaches cgroupfs *inside* sysfs so path traversal finds it correctly.
+    #[test]
+    fn test_cgroupfs_visible_with_mount_sys() {
+        if !is_root() {
+            eprintln!("Skipping test_cgroupfs_visible_with_mount_sys: requires root");
+            return;
+        }
+        let Some(rootfs) = ensure_alpine() else {
+            eprintln!("Skipping test_cgroupfs_visible_with_mount_sys: alpine-rootfs not found");
+            return;
+        };
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "stat /sys/fs/cgroup 2>&1 && echo OK"])
+            .with_image_layers(vec![rootfs.clone()])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS | Namespace::PID)
+            .with_proc_mount()
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("spawn image container");
+
+        let (status, stdout, stderr) = child.wait_with_output().expect("wait");
+        let out = String::from_utf8_lossy(&stdout);
+        let err = String::from_utf8_lossy(&stderr);
+
+        assert!(
+            status.success() && out.contains("OK"),
+            "/sys/fs/cgroup not reachable in image-layer container (#455)\nstdout: {out}\nstderr: {err}"
+        );
+    }
+
+    /// Non-privileged image containers must see /sys/fs/cgroup as read-only (#455).
+    #[test]
+    fn test_cgroupfs_readonly_in_nonprivileged_container() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_cgroupfs_readonly_in_nonprivileged_container: requires root"
+            );
+            return;
+        }
+        let Some(rootfs) = ensure_alpine() else {
+            eprintln!(
+                "Skipping test_cgroupfs_readonly_in_nonprivileged_container: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        // Check /proc/mounts for the cgroupfs entry — it should be mounted 'ro'.
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "grep cgroup /proc/mounts"])
+            .with_image_layers(vec![rootfs.clone()])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS | Namespace::PID)
+            .with_proc_mount()
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn");
+
+        let (_status, stdout, _stderr) = child.wait_with_output().expect("wait");
+        let mounts = String::from_utf8_lossy(&stdout);
+
+        let cg_line = mounts.lines().find(|l| {
+            let f: Vec<&str> = l.split_whitespace().collect();
+            f.len() >= 4 && f[1] == "/sys/fs/cgroup"
+        });
+        assert!(
+            cg_line.is_some(),
+            "/sys/fs/cgroup missing from /proc/mounts in image-layer container (#455);\nmounts:\n{mounts}"
+        );
+        let opts = cg_line
+            .and_then(|l| l.split_whitespace().nth(3))
+            .unwrap_or("");
+        assert!(
+            opts.split(',').any(|o| o == "ro"),
+            "non-privileged /sys/fs/cgroup should be read-only; mount options: {opts} (#455)"
+        );
+    }
+
+    /// Privileged image containers must see /sys/fs/cgroup as read-write (#455).
+    #[test]
+    fn test_cgroupfs_readwrite_in_privileged_container() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_cgroupfs_readwrite_in_privileged_container: requires root"
+            );
+            return;
+        }
+        let Some(rootfs) = ensure_alpine() else {
+            eprintln!(
+                "Skipping test_cgroupfs_readwrite_in_privileged_container: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "grep cgroup /proc/mounts"])
+            .with_image_layers(vec![rootfs.clone()])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS | Namespace::PID)
+            .with_proc_mount()
+            .with_privileged()
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn privileged");
+
+        let (_status, stdout, _stderr) = child.wait_with_output().expect("wait");
+        let mounts = String::from_utf8_lossy(&stdout);
+
+        let cg_line = mounts.lines().find(|l| {
+            let f: Vec<&str> = l.split_whitespace().collect();
+            f.len() >= 4 && f[1] == "/sys/fs/cgroup"
+        });
+        assert!(
+            cg_line.is_some(),
+            "/sys/fs/cgroup missing from /proc/mounts in privileged image-layer container (#455);\nmounts:\n{mounts}"
+        );
+        let opts = cg_line
+            .and_then(|l| l.split_whitespace().nth(3))
+            .unwrap_or("");
+        assert!(
+            !opts.split(',').any(|o| o == "ro"),
+            "privileged /sys/fs/cgroup should be read-write; mount options: {opts} (#455)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- When `mount_sys=true` (image-layer containers via `with_image_layers`), a fresh sysfs is mounted at `/sys` after `pivot_root`. The cgroupfs was previously bind-mounted into `bind_mounts` before `pivot_root`, so after sysfs mounted at `/sys` the bind was shadowed — path traversal entered sysfs and found sysfs's own virtual `fs/cgroup/` directory instead of the real cgroupfs.
- Fix uses a staging bind at `<effective_root>/.cg_tmp` before `pivot_root`, then `MS_MOVE`s it onto `/sys/fs/cgroup` after sysfs is mounted. This attaches cgroupfs inside the sysfs tree so path traversal finds it correctly.
- RO/RW semantics (privileged vs non-privileged) preserved via follow-up remount.
- When `mount_sys=false` (plain chroot containers), the old bind_mounts path is unchanged.
- Note: O_PATH fd approach was attempted first but fails after `MNT_DETACH` because the host cgroupfs is no longer in the namespace mount table — the bind-from-fd returns EINVAL.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` (392 passed)
- [x] `sudo -E cargo test --test integration_tests issue_455_cgroupfs` — 3 new tests pass
- [x] `sudo -E cargo test --test integration_tests issue_452_sysfs` — 3 existing #452 tests still pass
- [x] Full integration suite: 435 passed, 2 networking parallel-flakes (pre-existing, pass in isolation)

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)