### PR TITLE
fix(cri): auto-create missing HostPath dirs + zombie-proof sandbox liveness (#445 #461)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.57"
+version = "0.65.58"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ h2 = { path = "vendor/h2" }
 
 [package]
 name = "pelagos"
-version = "0.65.57"
+version = "0.65.58"
 edition = "2021"
 rust-version = "1.76"
 description = "Fast Linux container runtime — OCI-compatible, namespaces, cgroups v2, seccomp, networking, image management"

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5694,3 +5694,27 @@ under 4 s. **Why it matters:** `cmd_stop` uses `is_live_process(pid)` (reads
 that had already released its ports. A regression here means `pelagos stop` would hang for
 5 s on a zombie during the pod restart cycle, delaying the replacement pod unnecessarily
 (#459).
+
+## `issue_461_sandbox_zombie_liveness::test_sandbox_is_alive_false_for_zombie`
+**Requires root.** Spawns a `sleep` process, SIGKILLs it without calling `wait()` (leaving
+it as a zombie), constructs a `SandboxState` with the zombie's PID, and asserts
+`is_alive()` returns false. **Why it matters:** the old `kill(pid, 0)` implementation
+returns 0 for zombie processes (they remain in the process table until reaped), causing
+`with_sandbox()` to believe the pause is alive. It would then call `setns()` on the
+zombie's `/proc/<pid>/ns/{ipc,uts}`, which fails with EINVAL when the zombie's PID has
+been recycled. This was the root cause of containers with `seccompProfile: RuntimeDefault`
+reporting "Failed to spawn process: Invalid argument" (#461). The fix reads
+`/proc/<pid>/status` and checks the `State:` field.
+
+## `issue_461_sandbox_zombie_liveness::test_sandbox_is_alive_true_for_running`
+**Requires root.** Spawns a `sleep` process, constructs a `SandboxState` with its PID, and
+asserts `is_alive()` returns true. **Why it matters:** sanity-checks that the zombie-proof
+fix does not regress the normal case — a healthy pause process must still be considered
+alive so containers can join its namespaces.
+
+## `issue_461_sandbox_zombie_liveness::test_sandbox_is_alive_false_for_reaped`
+**Requires root.** Spawns a `sleep` process, SIGKILLs it, calls `wait()` to reap it (so
+`/proc/<pid>/` disappears entirely), then asserts `is_alive()` returns false. **Why it
+matters:** belt-and-suspenders coverage — once a zombie has been reaped, `/proc/<pid>/status`
+no longer exists and the function must handle the `Err(_)` branch, returning false without
+panicking.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1762,6 +1762,22 @@ impl RuntimeService for RuntimeSvc {
         }
 
         for m in &container.mounts {
+            // Auto-create missing HostPath source directories (#445).
+            // containerd/CRI-O silently create the source when hostPath.type=""
+            // (unset) — a chicken-and-egg that some workloads (e.g. KubeVirt
+            // virt-handler) depend on: the daemon creates the dir; the container
+            // then populates it on first run. ENOENT from the bind mount otherwise
+            // keeps the container stuck in RunContainerError indefinitely.
+            if !m.host_path.is_empty() && !std::path::Path::new(&m.host_path).exists() {
+                if let Err(e) = std::fs::create_dir_all(&m.host_path) {
+                    log::warn!(
+                        "start_container {}: could not create missing HostPath source '{}': {}",
+                        container_id,
+                        m.host_path,
+                        e
+                    );
+                }
+            }
             args.push("-v".into());
             let mut spec = format!("{}:{}", m.host_path, m.container_path);
             // recursive_read_only (#356) → :rro (mount_setattr AT_RECURSIVE);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -211,13 +211,25 @@ impl SandboxState {
         PathBuf::from(format!("/proc/{}/ns/pid", self.pause_pid))
     }
 
-    /// Returns true if the pause process is still alive.
+    /// Returns true if the pause process is still alive and not a zombie.
+    ///
+    /// `kill(pid, 0)` returns 0 for zombie processes (they remain in the process
+    /// table until reaped), causing false positives: a zombie pause would pass
+    /// the is_alive check but its /proc/<pid>/ns/{ipc,uts} may belong to a
+    /// different process if the PID was recycled.  Read /proc/status instead.
     pub fn is_alive(&self) -> bool {
         if self.pause_pid <= 0 {
             return false;
         }
-        // kill(pid, 0) — check existence without sending a signal.
-        unsafe { libc::kill(self.pause_pid, 0) == 0 }
+        match std::fs::read_to_string(format!("/proc/{}/status", self.pause_pid)) {
+            Err(_) => false,
+            Ok(s) => s
+                .lines()
+                .find(|l| l.starts_with("State:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .map(|c| !c.starts_with('Z'))
+                .unwrap_or(false),
+        }
     }
 }
 

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -1176,10 +1176,11 @@ pub fn apply_filter_no_nnp(program: &BpfProgram) -> Result<(), io::Error> {
         )
     };
     if result != 0 {
-        Err(io::Error::other(format!(
-            "Failed to apply seccomp filter (no-nnp): {}",
-            io::Error::last_os_error()
-        )))
+        // Preserve the raw errno so pre_exec propagates the real error code
+        // (io::Error::other loses raw_os_error, which the error pipe serialises
+        // as EINVAL, hiding the actual cause — EACCES = no caps/no NNP,
+        // EFAULT = bad BPF pointer, EINVAL = invalid program).
+        Err(io::Error::last_os_error())
     } else {
         Ok(())
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -30781,3 +30781,125 @@ mod issue_459_cmd_stop_cgroup_first {
         let _ = std::fs::remove_dir_all(&state_dir);
     }
 }
+
+/// Issue #461 — SandboxState::is_alive() must return false for zombie processes.
+///
+/// The old implementation used `kill(pid, 0)` which returns 0 for zombies (they
+/// remain in the process table until reaped), causing a false-positive: pelagos
+/// would believe the pause is alive, attempt to join its /proc/<pid>/ns/{ipc,uts}
+/// namespaces via setns(), fail with EINVAL (the zombie's namespace may no longer
+/// be valid), and report a misleading "Failed to spawn process: Invalid argument".
+///
+/// The fix reads /proc/<pid>/status and checks the State: field, returning false
+/// for 'Z' (zombie).
+mod issue_461_sandbox_zombie_liveness {
+    use pelagos::sandbox::SandboxState;
+
+    fn make_zombie() -> (u32, std::process::Child) {
+        // Spawn a child and immediately SIGKILL it without calling wait() — it
+        // becomes a zombie and stays in the process table until we reap it.
+        let child = std::process::Command::new("sleep")
+            .arg("300")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        // Wait briefly so the kernel transitions it to zombie state.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        (pid, child)
+    }
+
+    fn fake_sandbox(pid: u32) -> SandboxState {
+        SandboxState {
+            id: "test-sandbox".to_string(),
+            name: None,
+            pause_pid: pid as i32,
+            ns_name: String::new(),
+            veth_host: String::new(),
+            container_ip: String::new(),
+            namespaces: Default::default(),
+        }
+    }
+
+    /// SandboxState::is_alive() returns false for a zombie process.
+    ///
+    /// Requires root (spawning and signaling processes). Verifies that the
+    /// zombie-proof liveness check in sandbox.rs does not return true for a
+    /// process that has exited but not yet been reaped — such a "pause" would
+    /// cause setns() to fail with EINVAL when the container tries to join its
+    /// namespace (#461).
+    #[test]
+    fn test_sandbox_is_alive_false_for_zombie() {
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!("SKIP test_sandbox_is_alive_false_for_zombie: requires root");
+            return;
+        }
+
+        let (pid, mut child) = make_zombie();
+        let sandbox = fake_sandbox(pid);
+
+        assert!(
+            !sandbox.is_alive(),
+            "is_alive() must return false for zombie pid={pid} (#461)"
+        );
+
+        // Reap the zombie so it doesn't linger.
+        let _ = child.wait();
+    }
+
+    /// SandboxState::is_alive() returns true for a genuinely running process.
+    ///
+    /// Sanity check: the zombie-proof fix must not regress the normal case where
+    /// the pause process is alive and well.
+    #[test]
+    fn test_sandbox_is_alive_true_for_running() {
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!("SKIP test_sandbox_is_alive_true_for_running: requires root");
+            return;
+        }
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        let sandbox = fake_sandbox(pid);
+
+        assert!(
+            sandbox.is_alive(),
+            "is_alive() must return true for running pid={pid}"
+        );
+
+        unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        let _ = child.wait();
+    }
+
+    /// SandboxState::is_alive() returns false for a pid that no longer exists.
+    ///
+    /// Belt-and-suspenders: the process has been reaped and /proc/<pid>/status
+    /// is gone.  is_alive() must return false.
+    #[test]
+    fn test_sandbox_is_alive_false_for_reaped() {
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!("SKIP test_sandbox_is_alive_false_for_reaped: requires root");
+            return;
+        }
+
+        let (pid, mut child) = make_zombie();
+        // Reap the zombie — /proc/<pid>/ disappears.
+        let _ = child.wait();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let sandbox = fake_sandbox(pid);
+        assert!(
+            !sandbox.is_alive(),
+            "is_alive() must return false for fully reaped pid={pid}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **#445**: `create_dir_all` missing HostPath source dirs in `start_container` before building the bind-mount spec. containerd/CRI-O create missing dirs for `hostPath.type=""` (unset); workloads like KubeVirt virt-handler depend on this to bootstrap host dirs on fresh nodes.
- **#461**: Replace `kill(pid, 0)` in `SandboxState::is_alive()` with `/proc/<pid>/status State:` check. Zombie pause processes pass `kill(pid, 0)` but their namespace paths become invalid once the PID is recycled — causing `setns()` to fail with EINVAL, surfacing as "Failed to spawn process: Invalid argument" for containers with `seccompProfile: RuntimeDefault`.
- **seccomp.rs**: `apply_filter_no_nnp()` now returns `io::Error::last_os_error()` instead of `io::Error::other(...)` so the pre_exec error pipe preserves the real errno (EACCES, EFAULT, etc.) instead of always reporting EINVAL.
- **#444**: Confirmed already fixed in #452/#455; issue closed.

## Test plan

- [ ] `sudo -E cargo test --test integration_tests issue_461_sandbox_zombie_liveness` — 3 new tests: zombie returns false, running returns true, reaped returns false
- [ ] `sudo -E cargo test --test integration_tests issue_459_cmd_stop_cgroup_first` — existing 3 tests continue to pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)