### PR TITLE
fix(image): own multi-arch index resolution so mirror repo is preserved (#407)

### DIFF
--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -365,8 +365,8 @@ async fn pull_image(
     password: Option<&str>,
     insecure: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use oci_client::manifest::OciManifest;
     use oci_client::client::current_platform_resolver;
+    use oci_client::manifest::OciManifest;
     use oci_client::{Client, Reference as OciRef};
 
     // For pinned (immutable) tags, skip the network entirely if the image and
@@ -439,9 +439,8 @@ async fn pull_image(
     let (manifest, resolved_ref, digest) = match top_manifest {
         OciManifest::Image(m) => (m, oci_ref.clone(), top_digest),
         OciManifest::ImageIndex(idx) => {
-            let platform_digest = current_platform_resolver(&idx.manifests).ok_or(
-                "image index contains no manifest for the current platform",
-            )?;
+            let platform_digest = current_platform_resolver(&idx.manifests)
+                .ok_or("image index contains no manifest for the current platform")?;
             let child_ref = oci_ref.clone_with_digest(platform_digest.clone());
             log::debug!(
                 "pull: multi-arch index resolved to platform digest {}",
@@ -453,9 +452,7 @@ async fn pull_image(
                 .map_err(|e| format!("failed to pull platform manifest: {}", e))?;
             match child_manifest {
                 OciManifest::Image(m) => (m, child_ref, child_digest),
-                OciManifest::ImageIndex(_) => {
-                    return Err("nested image index not supported".into())
-                }
+                OciManifest::ImageIndex(_) => return Err("nested image index not supported".into()),
             }
         }
     };

--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -365,6 +365,8 @@ async fn pull_image(
     password: Option<&str>,
     insecure: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use oci_client::manifest::OciManifest;
+    use oci_client::client::current_platform_resolver;
     use oci_client::{Client, Reference as OciRef};
 
     // For pinned (immutable) tags, skip the network entirely if the image and
@@ -390,36 +392,83 @@ async fn pull_image(
 
     let client = Client::new(oci_client_config(registry, insecure));
 
-    let manifest_result = client.pull_manifest_and_config(&oci_ref, &auth).await;
-    let (manifest, digest, config_json) = match manifest_result {
-        Ok(r) => r,
-        Err(e) if is_transport_error(&e) => {
-            // Stale pooled connection — create a fresh client and retry once.
-            log::debug!("pull: manifest transport error, retrying with fresh connection: {e}");
-            Client::new(oci_client_config(registry, insecure))
-                .pull_manifest_and_config(&oci_ref, &auth)
-                .await
-                .map_err(|e| format!("failed to pull manifest: {}", oci_err(registry, e)))?
-        }
-        Err(e) if is_dockerhub_library_not_found(registry, &oci_ref, &e) => {
-            // Docker Hub returns 401 for nonexistent public images to prevent
-            // name enumeration.  Surface this as "not found" with a colon hint
-            // when the user omitted the separator between image name and tag.
-            let image_name = oci_ref.repository().trim_start_matches("library/");
-            let mut msg = format!(
-                "image not found: '{}' does not exist on Docker Hub",
-                image_name
-            );
-            if !original_ref.contains(':') && !original_ref.contains('/') {
-                msg.push_str(&format!(
-                    "\n  hint: to specify a tag use a colon, e.g. '{}:<tag>'",
-                    original_ref
-                ));
+    // Pull the top-level manifest.  For multi-arch images this is an
+    // OciManifest::ImageIndex; for single-arch it is OciManifest::Image.
+    // We resolve the image index ourselves rather than delegating to
+    // pull_manifest_and_config so that the mirror registry + repository are
+    // provably preserved when fetching the platform child manifest.
+    // Delegating to oci-client's internal resolution can lose the repo context
+    // for certain mirror/registry combinations, producing a mangled
+    // `library/sha256` repository name and a cache miss on every multi-arch
+    // pull. (#407)
+    let (top_manifest, top_digest) = {
+        let r = client.pull_manifest(&oci_ref, &auth).await;
+        match r {
+            Ok(r) => r,
+            Err(e) if is_transport_error(&e) => {
+                log::debug!("pull: manifest transport error, retrying with fresh connection: {e}");
+                Client::new(oci_client_config(registry, insecure))
+                    .pull_manifest(&oci_ref, &auth)
+                    .await
+                    .map_err(|e| format!("failed to pull manifest: {}", oci_err(registry, e)))?
             }
-            return Err(msg.into());
+            Err(e) if is_dockerhub_library_not_found(registry, &oci_ref, &e) => {
+                let image_name = oci_ref.repository().trim_start_matches("library/");
+                let mut msg = format!(
+                    "image not found: '{}' does not exist on Docker Hub",
+                    image_name
+                );
+                if !original_ref.contains(':') && !original_ref.contains('/') {
+                    msg.push_str(&format!(
+                        "\n  hint: to specify a tag use a colon, e.g. '{}:<tag>'",
+                        original_ref
+                    ));
+                }
+                return Err(msg.into());
+            }
+            Err(e) => {
+                return Err(format!("failed to pull manifest: {}", oci_err(registry, e)).into())
+            }
         }
-        Err(e) => return Err(format!("failed to pull manifest: {}", oci_err(registry, e)).into()),
     };
+
+    // Resolve a multi-arch image index to the current platform manifest.
+    // The child reference is built with clone_with_digest on oci_ref so the
+    // mirror host + repository (`library/alpine`, not `library/sha256`) are
+    // preserved in every subsequent request. (#407)
+    let (manifest, resolved_ref, digest) = match top_manifest {
+        OciManifest::Image(m) => (m, oci_ref.clone(), top_digest),
+        OciManifest::ImageIndex(idx) => {
+            let platform_digest = current_platform_resolver(&idx.manifests).ok_or(
+                "image index contains no manifest for the current platform",
+            )?;
+            let child_ref = oci_ref.clone_with_digest(platform_digest.clone());
+            log::debug!(
+                "pull: multi-arch index resolved to platform digest {}",
+                platform_digest
+            );
+            let (child_manifest, child_digest) = client
+                .pull_manifest(&child_ref, &auth)
+                .await
+                .map_err(|e| format!("failed to pull platform manifest: {}", e))?;
+            match child_manifest {
+                OciManifest::Image(m) => (m, child_ref, child_digest),
+                OciManifest::ImageIndex(_) => {
+                    return Err("nested image index not supported".into())
+                }
+            }
+        }
+    };
+
+    // Pull config blob using the resolved (possibly child) reference so that
+    // blob requests also go to the correct mirror path. (#407)
+    let mut config_bytes: Vec<u8> = Vec::new();
+    client
+        .pull_blob(&resolved_ref, &manifest.config, &mut config_bytes)
+        .await
+        .map_err(|e| format!("failed to pull config blob: {}", e))?;
+    let config_json =
+        String::from_utf8(config_bytes).map_err(|_| "image config is not valid UTF-8")?;
 
     println!(
         "  Manifest: {} ({} layers)",
@@ -463,7 +512,7 @@ async fn pull_image(
 
         let mut blob_data: Vec<u8> = Vec::new();
         client
-            .pull_blob(&oci_ref, layer_desc, &mut blob_data)
+            .pull_blob(&resolved_ref, layer_desc, &mut blob_data)
             .await
             .map_err(|e| format!("failed to pull layer {}: {}", layer_digest, e))?;
 

--- a/src/registry_mirror.rs
+++ b/src/registry_mirror.rs
@@ -141,4 +141,24 @@ mod tests {
     fn test_normalise_registry_key_index_docker_io() {
         assert_eq!(normalise_registry_key("index.docker.io"), "docker.io");
     }
+
+    #[test]
+    fn test_rewrite_reference_multiarch_child_digest() {
+        // When pull_image resolves a multi-arch image index it uses
+        // `oci_ref.clone_with_digest(child_digest)` to build the child reference.
+        // That produces `repo@sha256:hex`, NOT the bare `sha256:hex`.  Verify
+        // that rewrite_reference handles the `repo@digest` form correctly so the
+        // mirror receives `/v2/library/alpine/manifests/sha256:...` and not the
+        // mangled `/v2/library/sha256/manifests/...` (#407).
+        let digest = "sha256:3805b9089afd837fcf858f26cbb4422ef713b95e31645402464024ccad3a926f";
+        // The reference built by clone_with_digest on `docker.io/library/alpine:latest`
+        // comes out as `docker.io/library/alpine@sha256:...`.
+        let child_ref = format!("docker.io/library/alpine@{}", digest);
+        let out = rewrite_reference(&child_ref, "http://nazgul:5000");
+        assert_eq!(
+            out,
+            format!("nazgul:5000/library/alpine@{}", digest),
+            "child manifest reference must preserve the image repo, not mangle digest to repo name"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces `pull_manifest_and_config` with explicit `pull_manifest` + index resolution in `pull_image`
- When the top-level manifest is an `OciManifest::ImageIndex`, selects the current platform via `current_platform_resolver` and builds the child reference with `clone_with_digest` on the original `oci_ref` (preserving the mirror registry + repository)
- Config blob and layer blobs are then fetched using the resolved child reference, not the original tag reference
- Adds a unit test documenting the correct `repo@sha256:digest` reference form vs the mangled `library/sha256` form

## Root cause

When `pull_manifest_and_config` encountered an image index, it resolved the platform manifest internally and then pulled the config blob using the **original** `image` reference. For certain Zot pull-through mirror setups, this caused the child manifest request to use `library/sha256` as the repository (where `sha256` was parsed as an image name from the bare digest string). The mirror returned 404, falling back to origin on every pull — defeating the cache for all multi-arch images (virtually every image on Docker Hub).

## Test plan

- [x] `cargo test --lib` passes (392 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] Unit test `test_rewrite_reference_multiarch_child_digest` documents the correct reference form
- [ ] Cluster: verify Zot access log shows `GET /v2/library/alpine/manifests/sha256:...` (with repo) instead of `GET /v2/library/sha256/manifests/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)