### PR TITLE
fix(container): set NNP before seccomp when no ambient caps (#461)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -192,6 +192,16 @@ available.
 
 ## Phase 1 Security Tests
 
+### `test_seccomp_with_nnp_no_ambient_caps`
+**Requires:** root, rootfs
+
+Regression test for #461. Combines `with_seccomp_default()` + `with_no_new_privileges(true)` +
+`drop_all_capabilities()` (no ambient caps) — the exact profile used by virt-controller and
+virt-operator pods (`seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`,
+`capabilities.drop: [ALL]`). The fix sets NNP before calling `prctl(PR_SET_SECCOMP)` when
+there are no ambient caps to re-raise post-setuid, eliminating the intermittent CAP_SYS_ADMIN
+dependency that caused EINVAL. Failure here means the #461 regression is back.
+
 ### `test_no_new_privileges`
 **Requires:** root, rootfs
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -5728,12 +5728,34 @@ impl Command {
                 }
 
                 // Step 7: Apply seccomp filter (no_new_privileges=true path only).
-                // NNP is now deferred to step 8.7, so we use apply_filter_no_nnp()
-                // here (CAP_SYS_ADMIN, still held before setuid at step 8.5).
                 // When no_new_privileges=false, seccomp was applied at step 4.849 using
                 // CAP_SYS_ADMIN (before capability drops), so no action needed here.
+                //
+                // Two sub-paths based on whether ambient caps need re-raising after setuid:
+                //
+                // A) No ambient caps (common case): set NNP now, then apply the filter.
+                //    This is the standard approach (runc, containerd) — NNP satisfies the
+                //    kernel's privilege check without needing CAP_SYS_ADMIN (#461).
+                //    Step 8.7 repeats the NNP prctl (idempotent, harmless).
+                //
+                // B) Ambient caps present: NNP must stay deferred until step 8.7 so that
+                //    PR_CAP_AMBIENT_RAISE at step 8.5 (post-setuid) still works (#447).
+                //    Use CAP_SYS_ADMIN (still held here) via apply_filter_no_nnp().
                 if no_new_privileges {
                     if let Some(ref filter) = seccomp_filter {
+                        if ambient_cap_numbers.is_empty() {
+                            // Path A: set NNP first — always reliable (#461).
+                            const PR_SET_NO_NEW_PRIVS: i32 = 38;
+                            let r = libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+                            if r != 0 {
+                                return Err(pre_exec_err(
+                                    "PR_SET_NO_NEW_PRIVS",
+                                    io::Error::last_os_error(),
+                                ));
+                            }
+                        }
+                        // NNP now set (path A) or CAP_SYS_ADMIN still held (path B):
+                        // either satisfies the kernel's seccomp privilege check.
                         crate::seccomp::apply_filter_no_nnp(filter)?;
                     }
                 }
@@ -8553,9 +8575,19 @@ impl Command {
                 }
 
                 // Apply seccomp (no_new_privileges=true path only, mirrors spawn() step 7).
-                // Uses apply_filter_no_nnp() — NNP is deferred to step 8.7 (#447).
+                // See step 7 comment in spawn() for the two-path logic (#447 #461).
                 if no_new_privileges {
                     if let Some(ref filter) = seccomp_filter {
+                        if ambient_cap_numbers.is_empty() {
+                            const PR_SET_NO_NEW_PRIVS: i32 = 38;
+                            let r = libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+                            if r != 0 {
+                                return Err(pre_exec_err(
+                                    "PR_SET_NO_NEW_PRIVS",
+                                    io::Error::last_os_error(),
+                                ));
+                            }
+                        }
                         crate::seccomp::apply_filter_no_nnp(filter)?;
                     }
                 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -964,6 +964,46 @@ mod security {
         );
     }
 
+    /// Regression test for #461: containers with seccompProfile=RuntimeDefault +
+    /// allowPrivilegeEscalation=false (no_new_privileges=true, no ambient caps) must
+    /// start successfully.  Previously `apply_filter_no_nnp()` intermittently returned
+    /// EINVAL because it relied on CAP_SYS_ADMIN; the fix sets NNP first so the kernel
+    /// allows the filter installation via task_no_new_privs() instead.
+    #[test]
+    fn test_seccomp_with_nnp_no_ambient_caps() {
+        if !is_root() {
+            eprintln!("Skipping test_seccomp_with_nnp_no_ambient_caps: requires root");
+            return;
+        }
+
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_seccomp_with_nnp_no_ambient_caps: alpine-rootfs not found");
+            return;
+        };
+
+        // This combination is exactly what virt-controller / virt-operator use:
+        //   seccompProfile: RuntimeDefault  →  with_seccomp_default()
+        //   allowPrivilegeEscalation: false →  with_no_new_privileges(true)
+        //   capabilities.drop: ALL          →  drop_all_capabilities() (no ambient caps)
+        let mut child = Command::new("/bin/ash")
+            .args(["-c", "grep 'NoNewPrivs:.*1' /proc/self/status"])
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT)
+            .with_proc_mount()
+            .with_seccomp_default()
+            .with_no_new_privileges(true)
+            .drop_all_capabilities()
+            .spawn()
+            .expect("spawn must succeed — EINVAL here means #461 regression");
+
+        let status = child.wait().expect("wait failed");
+        assert!(status.success(), "NNP must be visible inside the container");
+    }
+
     #[test]
     fn test_no_new_privileges() {
         if !is_root() {


### PR DESCRIPTION
## Summary

- In the `no_new_privileges=true` path, `apply_filter_no_nnp()` was relying on `CAP_SYS_ADMIN` to install the seccomp filter without first setting `PR_SET_NO_NEW_PRIVS`. On some nodes under certain conditions, `prctl(PR_SET_SECCOMP)` returned `EINVAL`, causing all `RuntimeDefault` containers (virt-controller, virt-operator) to fail intermittently.
- Fix: when no ambient caps need to be re-raised after setuid (the common case for `drop: ALL` containers), set NNP at step 7 **before** calling `prctl(PR_SET_SECCOMP)`. The kernel then permits the filter via `task_no_new_privs()` — no `CAP_SYS_ADMIN` required. This is the approach used by runc and containerd.
- When ambient caps **are** present, the existing `apply_filter_no_nnp()` path is preserved so that `PR_CAP_AMBIENT_RAISE` still works post-setuid (#447).
- Adds regression test covering the exact virt-controller security profile: `seccomp=default` + `NNP=true` + `drop_all_capabilities()`.

## Test plan

- [x] New test `security::test_seccomp_with_nnp_no_ambient_caps` passes
- [x] All 24 existing security integration tests pass
- [x] Unit tests pass (393/393)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)