### PR TITLE
fix(cri): escape $ in systemd-run args to prevent premature ${VAR} expansion (#483)

### DIFF
--- a/pelagos-cri/src/scope.rs
+++ b/pelagos-cri/src/scope.rs
@@ -31,6 +31,23 @@ use std::sync::OnceLock;
 /// first referenced; an optional shipped `pelagos.slice` may set properties.
 pub const SLICE: &str = "pelagos.slice";
 
+/// Escape a string for use as a systemd ExecStart argument.
+///
+/// systemd performs `$VAR` / `${VAR}` expansion on every token of an ExecStart line,
+/// including the arguments of a transient unit created by `systemd-run`. If a
+/// container's command or environment value contains a `$` reference (e.g. bash
+/// scripts that use `${BIN_PATH}`), systemd expands it against the *scope*
+/// environment — where the variable is unset — replacing it with an empty string
+/// before the container process ever runs.
+///
+/// The fix is to escape every `$` as `$$`. systemd interprets `$$` as a literal `$`
+/// and passes it through unchanged, so the container process (bash in this case)
+/// receives the original `${BIN_PATH}` and expands it correctly using the env vars
+/// set by pelagos via `Command::env()`.
+fn escape_systemd_arg(s: &str) -> String {
+    s.replace('$', "$$")
+}
+
 /// Whether this host is running under systemd and `systemd-run` is usable.
 ///
 /// Requires both a live systemd (`/run/systemd/system`) and `systemd-run` on PATH.
@@ -97,9 +114,9 @@ pub fn build_scope_argv(unit: &str, bin: &str, args: &[&str]) -> Vec<String> {
         format!("--unit={}", unit),
         "--quiet".to_string(),
         "--".to_string(),
-        bin.to_string(),
+        escape_systemd_arg(bin),
     ];
-    v.extend(args.iter().map(|s| s.to_string()));
+    v.extend(args.iter().map(|s| escape_systemd_arg(s)));
     v
 }
 
@@ -118,9 +135,9 @@ pub fn build_service_argv(unit: &str, bin: &str, args: &[&str]) -> Vec<String> {
         "--property=KillMode=mixed".to_string(),
         "--quiet".to_string(),
         "--".to_string(),
-        bin.to_string(),
+        escape_systemd_arg(bin),
     ];
-    v.extend(args.iter().map(|s| s.to_string()));
+    v.extend(args.iter().map(|s| escape_systemd_arg(s)));
     v
 }
 
@@ -191,6 +208,33 @@ mod tests {
         let sep = argv.iter().position(|s| s == "--").unwrap();
         assert_eq!(argv[sep + 1], "/usr/local/bin/pelagos");
         assert_eq!(argv[sep + 2], "sandbox");
+    }
+
+    #[test]
+    fn dollar_signs_in_args_are_escaped_for_systemd() {
+        // systemd expands $VAR / ${VAR} in ExecStart args; we must escape $ → $$
+        // so container bash scripts that reference env vars like ${BIN_PATH} are
+        // not expanded prematurely by systemd before the container runs.
+        let script = "bash -ec 'nsenter \"${BIN_PATH}/tool\"'";
+        let argv = build_scope_argv(
+            "pelagos-ctr-pcri-abc.scope",
+            "/usr/local/bin/pelagos",
+            &[
+                "run",
+                "--env",
+                "BIN_PATH=/k3s/bin",
+                "--",
+                "img",
+                "bash",
+                "-ec",
+                script,
+            ],
+        );
+        let escaped_script = argv.last().unwrap();
+        assert_eq!(escaped_script, "bash -ec 'nsenter \"$${BIN_PATH}/tool\"'");
+        // args without $ are unchanged
+        assert!(argv.contains(&"--env".to_string()));
+        assert!(argv.contains(&"BIN_PATH=/k3s/bin".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Root cause**: systemd performs `$VAR` / `${VAR}` expansion on all ExecStart tokens when creating a transient scope/service unit via `systemd-run`. Cilium's `apply-sysctl-overwrites` init container passes a bash script containing `${BIN_PATH}`; systemd expanded it against the scope environment (where `BIN_PATH` is not set) before pelagos ran, replacing it with an empty string and producing ExitCode 127.
- **Evidence**: trace logging (added in v0.65.69) showed `full pelagos argv` correctly containing `--env BIN_PATH=/var/lib/rancher/k3s/data/current/bin`, and `build_image_run` correctly logging 17 CLI env vars with BIN_PATH present — yet systemd emitted `Referenced but unset environment variable evaluates to an empty string: BIN_PATH` before pelagos could do anything. The bash `-c` script received `/cilium-sysctlfix` (empty prefix) instead of `/var/lib/rancher/k3s/data/current/bin/cilium-sysctlfix`.
- **Fix**: in `scope.rs`, escape every `$` → `$$` in all args passed to `systemd-run` (both `build_scope_argv` and `build_service_argv`). systemd interprets `$$` as a literal `$` and passes it through unchanged. The container process then receives the original `${BIN_PATH}` and bash expands it correctly using the env vars set by pelagos via `Command::env()`.

## Test plan

- [x] `cargo test -p pelagos-cri` — all 43 unit tests pass, including new `dollar_signs_in_args_are_escaped_for_systemd` test
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p pelagos-cri -- -D warnings` passes
- [ ] Deploy to ipc4 and verify `apply-sysctl-overwrites` completes successfully (Cilium pods reach Running state)

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)