### PR TITLE
feat(cdi): resolve CDI devices for GPU passthrough on the OCI bundle path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.80"
+version = "0.65.81"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",
@@ -2645,6 +2645,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2",
  "tar",
@@ -3702,6 +3703,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,6 +4537,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ sha2 = "0.10"  # SHA-256 for content-addressable layer digests
 ignore = "0.4"  # Gitignore-style pattern matching for .remignore
 ureq = "2"      # Blocking HTTP client for ADD URL downloads
 toml = { version = "0.8", features = ["parse"] }  # TOML config file parsing
+serde_yaml = "0.9"  # CDI (Container Device Interface) spec file parsing (/etc/cdi, /run/cdi)
 bzip2 = { version = "0.5", features = ["static"] }  # bz2 decompression; static links libbz2 for musl portability
 xz2 = { version = "0.1", features = ["static"] }    # xz decompression; static links liblzma for musl portability
 containerd-shim = "0.10"  # Shim v2 protocol (ttrpc) for containerd-shim-pelagos-wasm-v1 binary

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1215,6 +1215,23 @@ to `/scratch/test.txt`. Runs the full create→start→stopped lifecycle and ass
 `pelagos delete` succeeds. Failure indicates that OCI `mounts` entries are not being
 applied from `config.json`, or that tmpfs mount handling in `build_command()` is broken.
 
+### `test_oci_cdi_device_resolution`
+**Requires:** root, rootfs
+
+Regression test for #512 (NVIDIA GPU passthrough / CDI support). Writes a fake CDI
+spec (`test.pelagos.dev/gpu`) defining a device node, a driver-library mount, and a
+spec-level env var, to a temp directory pointed at via `PELAGOS_CDI_SPEC_DIRS`. The
+bundle's `config.json` requests the device only via a `cdi.k8s.io/`-prefixed
+annotation (`cdi.k8s.io/test-claim: test.pelagos.dev/gpu=0`) — it does not list the
+device node, mount, or env var directly. The container writes proof of each resolved
+edit to a host-visible bind mount and the test asserts all three are present:
+`/dev/cditest0` exists, the driver file's contents are visible at the CDI-specified
+mount destination, and the CDI-specified env var is in the process environment.
+Failure indicates `apply_cdi_devices()` in `oci.rs` is not parsing CDI spec files, not
+resolving the requested device name against the registry, or not merging one of the
+three `ContainerEdits` categories (deviceNodes / mounts / env) into the OCI config
+before spawn.
+
 ### `test_oci_capabilities`
 **Requires:** root, rootfs
 

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -1,0 +1,375 @@
+//! CDI (Container Device Interface) spec parsing and resolution.
+//!
+//! CDI is a sibling spec to the OCI Runtime Spec — <https://github.com/cncf-tags/container-device-interface>.
+//! Vendor tooling (e.g. `nvidia-ctk cdi generate`) writes declarative spec files
+//! describing what a fully-qualified device name (`vendor.com/class=name`, e.g.
+//! `nvidia.com/gpu=all`) needs injected into a container: device nodes, mounts,
+//! env vars, and hooks. The spec itself defines the default well-known search
+//! directories (`/etc/cdi`, `/var/run/cdi`) — there is no registry or discovery
+//! protocol; every CDI-aware engine just agrees to scan those paths by convention.
+//!
+//! Pelagos implements CDI resolution at the OCI bundle layer (`pelagos create`):
+//! when `config.json` carries `cdi.k8s.io/*`-prefixed annotations naming CDI
+//! devices, we parse the on-disk specs, resolve those names, and merge the
+//! resulting device nodes / mounts / env / hooks into the config before spawn.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+/// Default CDI spec search directories, per the CDI spec's well-known-locations
+/// convention. `/var/run/cdi` takes priority over `/etc/cdi` for devices defined
+/// in both (dynamic overrides static) — see `CdiRegistry::load`.
+pub fn default_spec_dirs() -> Vec<PathBuf> {
+    vec![PathBuf::from("/etc/cdi"), PathBuf::from("/var/run/cdi")]
+}
+
+/// Annotation key prefix used to request CDI devices in an OCI bundle's
+/// `config.json` `annotations` map, matching the convention used by
+/// CRI-O/containerd before Kubernetes grew a native `CDIDevices` CRI field:
+/// `cdi.k8s.io/<claim-name>: <comma-separated fully-qualified CDI device names>`.
+pub const ANNOTATION_PREFIX: &str = "cdi.k8s.io/";
+
+#[derive(Debug, thiserror::Error)]
+pub enum CdiError {
+    #[error("invalid CDI device name '{0}': expected 'vendor.com/class=name'")]
+    InvalidDeviceName(String),
+    #[error("CDI device '{0}' not found in any loaded spec")]
+    DeviceNotFound(String),
+    #[error("failed to read CDI spec dir {0}: {1}")]
+    ReadDir(PathBuf, io::Error),
+    #[error("failed to parse CDI spec {0}: {1}")]
+    Parse(PathBuf, String),
+}
+
+// ---------------------------------------------------------------------------
+// CDI spec file schema (subset of fields Pelagos consumes)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContainerEdits {
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default, rename = "deviceNodes")]
+    pub device_nodes: Vec<CdiDeviceNode>,
+    #[serde(default)]
+    pub mounts: Vec<CdiMount>,
+    #[serde(default)]
+    pub hooks: Vec<CdiHook>,
+}
+
+impl ContainerEdits {
+    fn merge(&mut self, other: &ContainerEdits) {
+        self.env.extend(other.env.iter().cloned());
+        self.device_nodes.extend(other.device_nodes.iter().cloned());
+        self.mounts.extend(other.mounts.iter().cloned());
+        self.hooks.extend(other.hooks.iter().cloned());
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CdiDeviceNode {
+    pub path: String,
+    /// Host path the node should be created from, if different from `path`.
+    #[serde(rename = "hostPath")]
+    pub host_path: Option<String>,
+    #[serde(rename = "type", default = "default_device_type")]
+    pub kind: String,
+    pub major: Option<i64>,
+    pub minor: Option<i64>,
+    #[serde(rename = "fileMode")]
+    pub file_mode: Option<u32>,
+    pub uid: Option<u32>,
+    pub gid: Option<u32>,
+}
+
+fn default_device_type() -> String {
+    "c".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CdiMount {
+    #[serde(rename = "hostPath")]
+    pub host_path: String,
+    #[serde(rename = "containerPath")]
+    pub container_path: String,
+    #[serde(default)]
+    pub options: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CdiHook {
+    #[serde(rename = "hookName")]
+    pub hook_name: String,
+    pub path: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CdiDevice {
+    pub name: String,
+    #[serde(rename = "containerEdits", default)]
+    pub container_edits: ContainerEdits,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CdiSpec {
+    #[allow(dead_code)]
+    #[serde(rename = "cdiVersion")]
+    pub cdi_version: String,
+    pub kind: String,
+    #[serde(default)]
+    pub devices: Vec<CdiDevice>,
+    #[serde(rename = "containerEdits", default)]
+    pub container_edits: ContainerEdits,
+}
+
+// ---------------------------------------------------------------------------
+// Registry: parsed specs, keyed by "vendor.com/class"
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+pub struct CdiRegistry {
+    /// kind ("vendor.com/class") -> spec
+    specs: HashMap<String, CdiSpec>,
+}
+
+impl CdiRegistry {
+    /// Scan `dirs` in order and parse every `*.yaml`/`*.yml`/`*.json` CDI spec
+    /// file found. Later directories override earlier ones for the same kind,
+    /// matching the CDI convention that dynamic (`/var/run/cdi`) specs take
+    /// priority over static (`/etc/cdi`) ones. Missing directories are skipped
+    /// (not an error — a host with no GPU simply has no `/etc/cdi`).
+    pub fn load(dirs: &[PathBuf]) -> Result<Self, CdiError> {
+        let mut specs = HashMap::new();
+        for dir in dirs {
+            let entries = match fs::read_dir(dir) {
+                Ok(e) => e,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(CdiError::ReadDir(dir.clone(), e)),
+            };
+            let mut paths: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| {
+                    matches!(
+                        p.extension().and_then(|e| e.to_str()),
+                        Some("yaml") | Some("yml") | Some("json")
+                    )
+                })
+                .collect();
+            paths.sort();
+            for path in paths {
+                let content = fs::read_to_string(&path)
+                    .map_err(|e| CdiError::Parse(path.clone(), e.to_string()))?;
+                let spec: CdiSpec = serde_yaml::from_str(&content)
+                    .map_err(|e| CdiError::Parse(path.clone(), e.to_string()))?;
+                specs.insert(spec.kind.clone(), spec);
+            }
+        }
+        Ok(Self { specs })
+    }
+
+    /// Resolve a fully-qualified CDI device name (`vendor.com/class=name`) into
+    /// the `ContainerEdits` it requires. `name` of `all` resolves to the union
+    /// of every device in that kind's spec (matching CDI's `=all` convention).
+    pub fn resolve(&self, qualified_name: &str) -> Result<ContainerEdits, CdiError> {
+        let (kind, name) = qualified_name
+            .rsplit_once('=')
+            .ok_or_else(|| CdiError::InvalidDeviceName(qualified_name.to_string()))?;
+        if kind.is_empty() || name.is_empty() || !kind.contains('/') {
+            return Err(CdiError::InvalidDeviceName(qualified_name.to_string()));
+        }
+        let spec = self
+            .specs
+            .get(kind)
+            .ok_or_else(|| CdiError::DeviceNotFound(qualified_name.to_string()))?;
+
+        let mut edits = ContainerEdits::default();
+        if name == "all" {
+            for dev in &spec.devices {
+                edits.merge(&dev.container_edits);
+            }
+        } else {
+            let dev = spec
+                .devices
+                .iter()
+                .find(|d| d.name == name)
+                .ok_or_else(|| CdiError::DeviceNotFound(qualified_name.to_string()))?;
+            edits.merge(&dev.container_edits);
+        }
+        // Spec-level edits apply to every device drawn from that spec.
+        edits.merge(&spec.container_edits);
+        Ok(edits)
+    }
+
+    /// Resolve multiple qualified device names, merging their edits together.
+    pub fn resolve_all(&self, names: &[String]) -> Result<ContainerEdits, CdiError> {
+        let mut edits = ContainerEdits::default();
+        for name in names {
+            edits.merge(&self.resolve(name)?);
+        }
+        Ok(edits)
+    }
+}
+
+/// Collect requested CDI device names from an OCI bundle's annotations map:
+/// every value under a `cdi.k8s.io/`-prefixed key, comma-separated.
+pub fn devices_from_annotations(annotations: &HashMap<String, String>) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut keys: Vec<&String> = annotations
+        .keys()
+        .filter(|k| k.starts_with(ANNOTATION_PREFIX))
+        .collect();
+    keys.sort();
+    for key in keys {
+        let value = &annotations[key];
+        for part in value.split(',') {
+            let part = part.trim();
+            if !part.is_empty() {
+                names.push(part.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// Directories to scan for CDI specs. Honors `PELAGOS_CDI_SPEC_DIRS` (colon-separated)
+/// for tests and non-standard installs; falls back to the spec's default locations.
+pub fn spec_dirs() -> Vec<PathBuf> {
+    match std::env::var("PELAGOS_CDI_SPEC_DIRS") {
+        Ok(val) if !val.is_empty() => val.split(':').map(PathBuf::from).collect(),
+        _ => default_spec_dirs(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn sample_spec() -> &'static str {
+        r#"
+cdiVersion: "0.6.0"
+kind: "vendor.com/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/gpu0"
+          type: "c"
+          major: 195
+          minor: 0
+      mounts:
+        - hostPath: "/usr/lib/gpu/libgpu.so.1"
+          containerPath: "/usr/lib/gpu/libgpu.so.1"
+          options: ["ro", "bind"]
+  - name: "1"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/gpu1"
+          type: "c"
+          major: 195
+          minor: 1
+containerEdits:
+  env:
+    - "GPU_VISIBLE=1"
+"#
+    }
+
+    fn write_spec(dir: &Path, name: &str, contents: &str) {
+        fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn resolve_single_device() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_spec(tmp.path(), "vendor.yaml", sample_spec());
+        let reg = CdiRegistry::load(&[tmp.path().to_path_buf()]).unwrap();
+
+        let edits = reg.resolve("vendor.com/gpu=0").unwrap();
+        assert_eq!(edits.device_nodes.len(), 1);
+        assert_eq!(edits.device_nodes[0].path, "/dev/gpu0");
+        assert_eq!(edits.mounts.len(), 1);
+        // Spec-level edits are always merged in.
+        assert_eq!(edits.env, vec!["GPU_VISIBLE=1".to_string()]);
+    }
+
+    #[test]
+    fn resolve_all_aggregates_devices() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_spec(tmp.path(), "vendor.yaml", sample_spec());
+        let reg = CdiRegistry::load(&[tmp.path().to_path_buf()]).unwrap();
+
+        let edits = reg.resolve("vendor.com/gpu=all").unwrap();
+        assert_eq!(edits.device_nodes.len(), 2);
+        assert_eq!(edits.env, vec!["GPU_VISIBLE=1".to_string()]);
+    }
+
+    #[test]
+    fn unknown_device_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_spec(tmp.path(), "vendor.yaml", sample_spec());
+        let reg = CdiRegistry::load(&[tmp.path().to_path_buf()]).unwrap();
+
+        assert!(matches!(
+            reg.resolve("vendor.com/gpu=99"),
+            Err(CdiError::DeviceNotFound(_))
+        ));
+        assert!(matches!(
+            reg.resolve("vendor.com/gpu"),
+            Err(CdiError::InvalidDeviceName(_))
+        ));
+    }
+
+    #[test]
+    fn missing_spec_dir_is_not_an_error() {
+        let reg = CdiRegistry::load(&[PathBuf::from("/no/such/cdi/dir")]).unwrap();
+        assert!(reg.specs.is_empty());
+    }
+
+    #[test]
+    fn later_dir_overrides_earlier_for_same_kind() {
+        let etc = tempfile::tempdir().unwrap();
+        let run = tempfile::tempdir().unwrap();
+        write_spec(etc.path(), "vendor.yaml", sample_spec());
+        // /run copy only has device "0", not "1" — proves it fully replaced /etc's spec.
+        write_spec(
+            run.path(),
+            "vendor.yaml",
+            r#"
+cdiVersion: "0.6.0"
+kind: "vendor.com/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/gpu0-override"
+          type: "c"
+          major: 195
+          minor: 0
+"#,
+        );
+        let reg = CdiRegistry::load(&[etc.path().to_path_buf(), run.path().to_path_buf()]).unwrap();
+        let edits = reg.resolve("vendor.com/gpu=0").unwrap();
+        assert_eq!(edits.device_nodes[0].path, "/dev/gpu0-override");
+        assert!(reg.resolve("vendor.com/gpu=1").is_err());
+    }
+
+    #[test]
+    fn devices_from_annotations_collects_prefixed_keys() {
+        let mut ann = HashMap::new();
+        ann.insert(
+            "cdi.k8s.io/claim1".to_string(),
+            "vendor.com/gpu=0, vendor.com/gpu=1".to_string(),
+        );
+        ann.insert("other.annotation".to_string(), "ignored".to_string());
+        let names = devices_from_annotations(&ann);
+        assert_eq!(names, vec!["vendor.com/gpu=0", "vendor.com/gpu=1"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ compile_error!(
 );
 
 pub mod build;
+pub mod cdi;
 pub mod cgroup;
 pub mod cgroup_rootless;
 pub mod compose;

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -90,7 +90,7 @@ pub struct OciUser {
     pub umask: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct OciLinux {
     #[serde(default)]
@@ -462,6 +462,98 @@ pub fn config_from_bundle(bundle: &Path) -> io::Result<OciConfig> {
     let config_path = bundle.join("config.json");
     let content = fs::read(&config_path)?;
     serde_json::from_slice(&content).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+// ---------------------------------------------------------------------------
+// CDI (Container Device Interface) resolution
+// ---------------------------------------------------------------------------
+
+/// If `config.annotations` names any CDI devices (via `cdi.k8s.io/*` keys), resolve
+/// them against the on-disk CDI registry and merge the resulting device nodes,
+/// mounts, env vars, and hooks into `config` in place. No-op when no CDI devices
+/// are requested — hosts without a GPU never touch `/etc/cdi`.
+fn apply_cdi_devices(config: &mut OciConfig) -> io::Result<()> {
+    let names = match &config.annotations {
+        Some(annotations) => crate::cdi::devices_from_annotations(annotations),
+        None => Vec::new(),
+    };
+    if names.is_empty() {
+        return Ok(());
+    }
+
+    let registry = crate::cdi::CdiRegistry::load(&crate::cdi::spec_dirs())
+        .map_err(|e| io::Error::other(format!("CDI: {e}")))?;
+    let edits = registry
+        .resolve_all(&names)
+        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, format!("CDI: {e}")))?;
+
+    if !edits.device_nodes.is_empty() {
+        let linux = config.linux.get_or_insert_with(OciLinux::default);
+        for dn in &edits.device_nodes {
+            let kind = dn.kind.chars().next().unwrap_or('c');
+            linux.devices.push(OciDevice {
+                path: dn.path.clone(),
+                kind: kind.to_string(),
+                major: dn.major.map(|m| m as u64),
+                minor: dn.minor.map(|m| m as u64),
+                file_mode: dn.file_mode.unwrap_or(0o666),
+                uid: dn.uid.unwrap_or(0),
+                gid: dn.gid.unwrap_or(0),
+            });
+        }
+    }
+
+    for m in &edits.mounts {
+        let mut options = m.options.clone();
+        if options.is_empty() {
+            options.push("bind".to_string());
+        }
+        config.mounts.push(OciMount {
+            destination: m.container_path.clone(),
+            mount_type: Some("bind".to_string()),
+            source: Some(m.host_path.clone()),
+            options,
+        });
+    }
+
+    if !edits.env.is_empty() {
+        let process = config.process.get_or_insert_with(|| OciProcess {
+            args: Vec::new(),
+            cwd: "/".to_string(),
+            env: Vec::new(),
+            user: None,
+            no_new_privileges: false,
+            terminal: false,
+            capabilities: None,
+            rlimits: Vec::new(),
+            oom_score_adj: None,
+        });
+        process.env.extend(edits.env.iter().cloned());
+    }
+
+    if !edits.hooks.is_empty() {
+        let hooks = config.hooks.get_or_insert_with(OciHooks::default);
+        for h in &edits.hooks {
+            let hook = OciHook {
+                path: h.path.clone(),
+                args: h.args.clone(),
+                env: h.env.clone(),
+                timeout: None,
+            };
+            match h.hook_name.as_str() {
+                "createRuntime" => hooks.create_runtime.push(hook),
+                "createContainer" => hooks.create_container.push(hook),
+                "startContainer" => hooks.start_container.push(hook),
+                "poststart" => hooks.poststart.push(hook),
+                "poststop" => hooks.poststop.push(hook),
+                // "prestart" and any unrecognized hookName default to prestart,
+                // matching the legacy (pre-hookName) CDI hook behavior.
+                _ => hooks.prestart.push(hook),
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1549,7 +1641,8 @@ pub fn cmd_create(
     }
 
     let bundle = bundle_path.canonicalize()?;
-    let config = config_from_bundle(&bundle)?;
+    let mut config = config_from_bundle(&bundle)?;
+    apply_cdi_devices(&mut config)?;
     fs::create_dir_all(&dir)?;
 
     // Ready pipe: grandchild writes PID → parent reads it.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5918,6 +5918,175 @@ mod oci_lifecycle {
         );
     }
 
+    /// Run a pelagos subcommand with extra environment variables set (rather than
+    /// inherited from the test process), so `PELAGOS_CDI_SPEC_DIRS` overrides don't
+    /// leak into the shared test-binary environment across parallel tests.
+    fn run_pelagos_with_env(args: &[&str], env: &[(&str, &str)]) -> (String, String, bool) {
+        if args.first() == Some(&"create") {
+            let tmp = tempfile::NamedTempFile::new().expect("tempfile for stderr");
+            let stderr_file = tmp.reopen().expect("reopen stderr tempfile");
+            let status = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+                .args(args)
+                .envs(env.iter().cloned())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::from(stderr_file))
+                .status()
+                .expect("failed to run pelagos create");
+            let stderr = std::fs::read_to_string(tmp.path()).unwrap_or_default();
+            return (String::new(), stderr, status.success());
+        }
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(args)
+            .envs(env.iter().cloned())
+            .output()
+            .expect("failed to run pelagos binary");
+        (
+            String::from_utf8_lossy(&output.stdout).into_owned(),
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+            output.status.success(),
+        )
+    }
+
+    /// test_oci_cdi_device_resolution
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Regression test for #512. Writes a fake CDI spec (`test.pelagos.dev/gpu`)
+    /// to a temp directory pointed at via `PELAGOS_CDI_SPEC_DIRS`, and a bundle
+    /// `config.json` that requests it via a `cdi.k8s.io/`-prefixed annotation
+    /// (`cdi.k8s.io/test-claim: test.pelagos.dev/gpu=0`) instead of listing the
+    /// device node / mount / env var directly. The container writes proof of each
+    /// resolved edit to a host-visible bind mount:
+    /// - the CDI-spec-defined device node exists at `/dev/cditest0`
+    /// - the CDI-spec-defined mount exposes the fake driver file's contents
+    /// - the CDI-spec-defined env var is present in the process environment
+    ///
+    /// Failure indicates `apply_cdi_devices()` in `oci.rs` is not parsing CDI
+    /// specs, not resolving the requested device name, or not merging one of the
+    /// three edit categories (deviceNodes / mounts / env) into the OCI config
+    /// before spawn.
+    #[test]
+    fn test_oci_cdi_device_resolution() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_cdi_device_resolution: requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping test_oci_cdi_device_resolution: alpine-rootfs not found");
+                return;
+            }
+        };
+
+        // Fake CDI spec dir + fake driver library the spec's mount points at.
+        let cdi_dir = tempfile::tempdir().expect("tempdir");
+        let driver_dir = tempfile::tempdir().expect("tempdir");
+        let driver_path = driver_dir.path().join("libcditest.so");
+        std::fs::write(&driver_path, "CDI_DRIVER_CONTENTS").unwrap();
+
+        let spec = format!(
+            r#"
+cdiVersion: "0.6.0"
+kind: "test.pelagos.dev/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/cditest0"
+          type: "c"
+          major: 511
+          minor: 0
+      mounts:
+        - hostPath: "{}"
+          containerPath: "/opt/cdi/libcditest.so"
+          options: ["ro", "bind"]
+containerEdits:
+  env:
+    - "CDI_TEST_VAR=present"
+"#,
+            driver_path.display()
+        );
+        std::fs::write(cdi_dir.path().join("vendor.yaml"), spec).unwrap();
+
+        // Host-visible dir the container writes its findings into.
+        let out_dir = tempfile::tempdir().expect("tempdir");
+
+        let bundle_dir = tempfile::tempdir().expect("tempdir");
+        std::os::unix::fs::symlink(&rootfs, bundle_dir.path().join("rootfs")).unwrap();
+        let config = format!(
+            r#"{{
+      "ociVersion": "1.0.2",
+      "root": {{"path": "rootfs"}},
+      "process": {{
+        "args": ["/bin/sh", "-c", "{{ test -c /dev/cditest0 && echo DEVICE_OK || echo DEVICE_MISSING; cat /opt/cdi/libcditest.so 2>&1; env | grep CDI_TEST_VAR; }} > /cdi-out/result.txt 2>&1"],
+        "cwd": "/",
+        "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+      }},
+      "mounts": [
+        {{"destination": "/cdi-out", "type": "bind", "source": "{}", "options": ["bind"]}}
+      ],
+      "linux": {{
+        "namespaces": [
+          {{"type": "mount"}},
+          {{"type": "uts"}},
+          {{"type": "pid"}}
+        ]
+      }},
+      "annotations": {{
+        "cdi.k8s.io/test-claim": "test.pelagos.dev/gpu=0"
+      }}
+    }}"#,
+            out_dir.path().display()
+        );
+        std::fs::write(bundle_dir.path().join("config.json"), config).unwrap();
+
+        let id = format!("test-oci-cdi-{}", std::process::id());
+        let cdi_env = [("PELAGOS_CDI_SPEC_DIRS", cdi_dir.path().to_str().unwrap())];
+
+        let (_, stderr, ok) = run_pelagos_with_env(
+            &["create", &id, bundle_dir.path().to_str().unwrap()],
+            &cdi_env,
+        );
+        assert!(ok, "pelagos create (CDI) failed: {}", stderr);
+
+        let (_, stderr, ok) = run_pelagos_with_env(&["start", &id], &cdi_env);
+        assert!(ok, "pelagos start (CDI) failed: {}", stderr);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            let (stdout, _, _) = run_pelagos(&["state", &id]);
+            if stdout.contains("\"stopped\"") {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                run_pelagos(&["delete", &id]);
+                panic!("CDI test container did not stop within 5 seconds");
+            }
+        }
+        let (_, stderr, ok) = run_pelagos(&["delete", &id]);
+        assert!(ok, "pelagos delete (CDI) failed: {}", stderr);
+
+        let result = std::fs::read_to_string(out_dir.path().join("result.txt"))
+            .expect("result.txt should have been written by the container");
+        assert!(
+            result.contains("DEVICE_OK"),
+            "CDI deviceNodes edit was not applied — /dev/cditest0 missing. Output:\n{}",
+            result
+        );
+        assert!(
+            result.contains("CDI_DRIVER_CONTENTS"),
+            "CDI mounts edit was not applied — driver file not visible. Output:\n{}",
+            result
+        );
+        assert!(
+            result.contains("CDI_TEST_VAR=present"),
+            "CDI env edit was not applied — env var missing. Output:\n{}",
+            result
+        );
+    }
+
     /// test_oci_capabilities
     ///
     /// Requires: root, alpine-rootfs.


### PR DESCRIPTION
## Summary
Implements CDI (Container Device Interface) spec parsing and resolution for the `pelagos create`/`start` OCI bundle path, unblocking NVIDIA GPU passthrough (#512). CDI was chosen over the legacy `nvidia-container-runtime` hook shim — it's the ecosystem's current recommended path (Podman/containerd/CRI-O all standardized on it) and avoids shelling out to an external hook binary.

- `src/cdi.rs` (new): parses CDI spec files from `/etc/cdi` + `/var/run/cdi` (overridable via `PELAGOS_CDI_SPEC_DIRS`), builds a registry keyed by `vendor.com/class`, resolves fully-qualified device names (including `=all`) into `ContainerEdits` (deviceNodes/mounts/env/hooks), merging in spec-level edits. `/var/run/cdi` overrides `/etc/cdi` for the same kind, per spec convention.
- `src/oci.rs`: `apply_cdi_devices()` reads `cdi.k8s.io/*`-prefixed annotations from `config.json`, resolves them against the registry, and merges the result into the OCI config before spawn — device nodes into `linux.devices`, mounts into `config.mounts`, env into `process.env`, hooks into the matching OCI hook bucket by `hookName`.

Scoped to the OCI bundle path only, since that's what pelagos-cri/k3s uses. `pelagos run --gpus` CLI convenience support is tracked separately in #513.

Closes #512.

## Test plan
- [x] `src/cdi.rs` unit tests: spec parsing, `=all` aggregation, spec-level edit merge, unknown-device error, missing-dir no-op, `/run` overriding `/etc` for the same kind, annotation collection
- [x] New integration test `test_oci_cdi_device_resolution`: fake CDI spec requested purely via a `cdi.k8s.io/` annotation, end-to-end through `pelagos create`/`start` — verifies the device node exists, the driver-file mount is visible, and the env var is set inside the container
- [x] Full `oci_lifecycle::*` suite (29 tests) passes — no regressions
- [x] Full `cargo test --lib` (403 tests) passes
- [x] `cargo fmt --check` clean; `cargo clippy --lib -- -D warnings` clean (pre-existing unrelated clippy failures on `main` in `compose.rs`/`paths.rs`/`dockerd_smoke.rs`/other `integration_tests.rs` lines confirmed via stash-diff, not touched by this change)
- [x] `docs/INTEGRATION_TESTS.md` updated with the new test's entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)