### PR TITLE
feat(cdi): resolve CDI devices on the pelagos run CLI path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.81"
+version = "0.65.82"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -419,6 +419,21 @@ This tests the `run.rs` parser path (distinct from `test_bind_mount_ro` which ca
 `:ro`/`:rw` from the mount-target path has regressed, causing the suffix to be treated
 as part of the filesystem path instead of a mount option.
 
+### `test_cli_device_flag_cdi_resolution`
+**Requires:** root, rootfs
+
+Regression test for #513 (NVIDIA GPU passthrough / CDI support on the `pelagos run`
+CLI path). Writes a fake CDI spec (`test.pelagos.dev/gpu`) defining a device node, a
+driver-library mount, and a spec-level env var, to a temp dir pointed at via
+`PELAGOS_CDI_SPEC_DIRS`. Runs `pelagos run --device test.pelagos.dev/gpu=0` (a value
+not starting with `/`, so `run.rs` dispatches it to `add_cdi_device()` instead of the
+existing host-device-path `add_device()`). Asserts the resolved device node exists,
+the resolved mount's contents are visible, and the resolved env var is set inside the
+container — the CLI-path counterpart to #512's `test_oci_cdi_device_resolution`.
+Failure indicates `add_cdi_device()` in `run.rs` is not resolving CDI device names
+passed via `--device`, or not merging one of the three `ContainerEdits` categories
+(deviceNodes/mounts/env) into the `Command` before spawn.
+
 ### `test_bind_mount_into_dev`
 **Requires:** root, rootfs
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -112,11 +112,18 @@ pub struct RunArgs {
     #[clap(long = "bind-ro")]
     pub bind_ro: Vec<String>,
 
-    /// Expose a host device inside the container.
-    /// Format: /host/path[:/container/path]
-    /// The host file is stat'd to obtain device type, major/minor, and mode.
-    /// Defaults container_path to host_path when omitted.
-    /// (repeatable)
+    /// Expose a host device inside the container, OR request a CDI
+    /// (Container Device Interface) device.
+    ///
+    /// Host device form: /host/path[:/container/path] — the host file is
+    /// stat'd to obtain device type, major/minor, and mode. container_path
+    /// defaults to host_path when omitted.
+    ///
+    /// CDI form (any value not starting with '/'): a fully-qualified CDI
+    /// device name, e.g. `nvidia.com/gpu=0` or `nvidia.com/gpu=all`.
+    /// Resolved against CDI spec files in /etc/cdi and /var/run/cdi
+    /// (nvidia-ctk cdi generate writes these); the resulting device nodes,
+    /// mounts, and env vars are merged into the container. (repeatable)
     #[clap(long = "device")]
     pub device: Vec<String>,
 
@@ -1024,7 +1031,11 @@ fn apply_cli_options(
         cmd = cmd.with_bind_mount_ro(src, tgt);
     }
     for d in &args.device {
-        cmd = add_device(cmd, d)?;
+        cmd = if d.starts_with('/') {
+            add_device(cmd, d)?
+        } else {
+            add_cdi_device(cmd, d)?
+        };
     }
     for t in &args.tmpfs {
         let (path, opts) = t.split_once(':').unwrap_or((t.as_str(), ""));
@@ -1334,6 +1345,59 @@ fn add_device(cmd: Command, spec: &str) -> Result<Command, Box<dyn std::error::E
         uid: 0,
         gid: 0,
     }))
+}
+
+/// Resolve a fully-qualified CDI device name (`vendor.com/class=name`, e.g.
+/// `nvidia.com/gpu=all`) against the on-disk CDI registry (`/etc/cdi`,
+/// `/var/run/cdi`, overridable via `PELAGOS_CDI_SPEC_DIRS`) and merge the
+/// resulting device nodes, mounts, and env vars into `cmd`.
+///
+/// Mirrors `apply_cdi_devices()` in `oci.rs` (used by the OCI bundle path,
+/// #512) for the everyday `pelagos run` CLI path (#513).
+fn add_cdi_device(
+    mut cmd: Command,
+    qualified_name: &str,
+) -> Result<Command, Box<dyn std::error::Error>> {
+    let registry = pelagos::cdi::CdiRegistry::load(&pelagos::cdi::spec_dirs())
+        .map_err(|e| format!("--device {}: {}", qualified_name, e))?;
+    let edits = registry
+        .resolve(qualified_name)
+        .map_err(|e| format!("--device {}: {}", qualified_name, e))?;
+
+    for dn in &edits.device_nodes {
+        let kind = dn.kind.chars().next().unwrap_or('c');
+        cmd = cmd.with_device(container::DeviceNode {
+            path: std::path::PathBuf::from(&dn.path),
+            kind,
+            major: dn.major.unwrap_or(0) as u64,
+            minor: dn.minor.unwrap_or(0) as u64,
+            mode: dn.file_mode.unwrap_or(0o666),
+            uid: dn.uid.unwrap_or(0),
+            gid: dn.gid.unwrap_or(0),
+        });
+    }
+    for m in &edits.mounts {
+        let is_ro = m.options.iter().any(|o| o == "ro");
+        cmd = if is_ro {
+            cmd.with_bind_mount_ro(&m.host_path, &m.container_path)
+        } else {
+            cmd.with_bind_mount(&m.host_path, &m.container_path)
+        };
+    }
+    for e in &edits.env {
+        if let Some((k, v)) = e.split_once('=') {
+            cmd = cmd.env(k, v);
+        }
+    }
+    if !edits.hooks.is_empty() {
+        log::warn!(
+            "CDI device '{}' defines {} hook(s); OCI lifecycle hooks are not yet \
+             supported on the `pelagos run` CLI path (only on the OCI bundle path) — ignoring",
+            qualified_name,
+            edits.hooks.len()
+        );
+    }
+    Ok(cmd)
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2162,6 +2162,107 @@ mod filesystem {
         );
     }
 
+    /// test_cli_device_flag_cdi_resolution
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Regression test for #513 (GPU passthrough on the `pelagos run` CLI /
+    /// non-bundle path). Writes a fake CDI spec (`test.pelagos.dev/gpu`) to a
+    /// temp dir pointed at via `PELAGOS_CDI_SPEC_DIRS`, then runs `pelagos run
+    /// --device test.pelagos.dev/gpu=0` (a CDI-qualified name, not a host
+    /// path) via the CLI binary so it exercises `run.rs`'s `add_cdi_device()`
+    /// dispatch (values not starting with `/` are treated as CDI device
+    /// names, distinct from the existing host-device-path `--device` form).
+    /// Asserts the resolved device node exists, the resolved mount's contents
+    /// are visible, and the resolved env var is set — the same three
+    /// `ContainerEdits` categories verified for the OCI bundle path in #512's
+    /// `test_oci_cdi_device_resolution`.
+    ///
+    /// Failure indicates `add_cdi_device()` in `run.rs` is not resolving CDI
+    /// device names passed via `--device`, or not merging deviceNodes/mounts/
+    /// env into the `Command` before spawn.
+    #[test]
+    fn test_cli_device_flag_cdi_resolution() {
+        if !is_root() {
+            eprintln!("Skipping test_cli_device_flag_cdi_resolution: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_cli_device_flag_cdi_resolution: alpine-rootfs not found");
+            return;
+        };
+
+        let cdi_dir = tempfile::tempdir().expect("tempdir");
+        let driver_dir = tempfile::tempdir().expect("tempdir");
+        let driver_path = driver_dir.path().join("libcditest.so");
+        std::fs::write(&driver_path, "CDI_DRIVER_CONTENTS").unwrap();
+
+        let spec = format!(
+            r#"
+cdiVersion: "0.6.0"
+kind: "test.pelagos.dev/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/cditest0"
+          type: "c"
+          major: 511
+          minor: 1
+      mounts:
+        - hostPath: "{}"
+          containerPath: "/opt/cdi/libcditest.so"
+          options: ["ro", "bind"]
+containerEdits:
+  env:
+    - "CDI_TEST_VAR=present"
+"#,
+            driver_path.display()
+        );
+        std::fs::write(cdi_dir.path().join("vendor.yaml"), spec).unwrap();
+
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .env("PELAGOS_CDI_SPEC_DIRS", cdi_dir.path())
+            .args([
+                "run",
+                "--network",
+                "loopback",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--device",
+                "test.pelagos.dev/gpu=0",
+                "/bin/sh",
+                "-c",
+                "test -c /dev/cditest0 && echo DEVICE_OK || echo DEVICE_MISSING; \
+                 cat /opt/cdi/libcditest.so 2>&1; env | grep CDI_TEST_VAR",
+            ])
+            .output()
+            .expect("pelagos run --device <cdi>");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stdout.contains("DEVICE_OK"),
+            "CDI deviceNodes edit was not applied via --device — /dev/cditest0 missing. \
+             stdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+        assert!(
+            stdout.contains("CDI_DRIVER_CONTENTS"),
+            "CDI mounts edit was not applied via --device — driver file not visible. \
+             stdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+        assert!(
+            stdout.contains("CDI_TEST_VAR=present"),
+            "CDI env edit was not applied via --device — env var missing. \
+             stdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+    }
+
     /// test_bind_mount_into_dev
     ///
     /// Requires: root, rootfs.


### PR DESCRIPTION
## Summary
Extends #512's CDI (Container Device Interface) support to the `pelagos run` CLI (non-bundle) path, per #513. Flagged high priority by the k3s-experiments agent via the agent-coordinator blackboard: they're standing up a standalone (non-k3s) NVIDIA DGX Spark node for a vLLM workload and need `pelagos run` GPU support directly, since #512 only wired up the OCI-bundle/CRI path.

- `src/cli/run.rs`: `--device` now accepts either a host device path (existing behavior, unchanged — still requires a leading `/`) or a fully-qualified CDI device name (e.g. `nvidia.com/gpu=0`, `nvidia.com/gpu=all`). `add_cdi_device()` resolves against the same `pelagos::cdi` registry from #512 and merges device nodes / mounts / env vars into the `Command` before spawn. CDI hooks are logged and intentionally skipped (no OCI-hook execution mechanism on this path) rather than silently dropped.
- No duplicated CDI parsing/resolution logic — reuses `src/cdi.rs` entirely.

Closes #513.

## Test plan
- [x] New integration test `test_cli_device_flag_cdi_resolution`: fake CDI spec requested via `pelagos run --device test.pelagos.dev/gpu=0`, verifies device node / mount / env var all land inside a real container (CLI-path counterpart to #512's `test_oci_cdi_device_resolution`)
- [x] `dev::*` (5 tests) + `filesystem::*` (14 tests) pass — no regressions to existing `--device` host-path behavior
- [x] Full `cargo test --lib` (403 tests) passes
- [x] `cargo fmt --check` clean; `cargo clippy --lib -- -D warnings` clean
- [x] `docs/INTEGRATION_TESTS.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)