### PR TITLE
feat(cdi): execute create-symlinks hook on the pelagos run CLI path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.82"
+version = "0.65.83"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -434,6 +434,24 @@ Failure indicates `add_cdi_device()` in `run.rs` is not resolving CDI device nam
 passed via `--device`, or not merging one of the three `ContainerEdits` categories
 (deviceNodes/mounts/env) into the `Command` before spawn.
 
+### `test_cli_device_flag_cdi_create_symlinks_hook`
+**Requires:** root, rootfs
+
+Regression test for #516. Reproduces the real NVIDIA CDI spec shape from the issue's
+repro: a `mounts` entry for a versioned driver lib (`libcditest.so.1.2.3`) plus a
+`createContainer` hook whose `args` are literally `nvidia-ctk hook create-symlinks
+--link A::B --link C::D` — the exact syntax `nvidia-ctk cdi generate` embeds to
+recreate the SONAME symlink chain. Before this fix, `pelagos run` resolved the mount
+but silently skipped the hook (logged a warning), leaving the unversioned symlink name
+missing — mirroring the real bug where `nvidia-smi` failed with "couldn't find
+libnvidia-ml.so" despite the versioned file being present. Asserts the two-hop symlink
+chain (`libcditest.so` -> `libcditest.so.1` -> `libcditest.so.1.2.3`) resolves to the
+mounted file's actual contents when read through the unversioned name, the same way
+`dlopen("libnvidia-ml.so")` would. Failure indicates
+`CdiHook::nvidia_create_symlinks_pairs()` in `cdi.rs` is not parsing `--link
+TARGET::LINK_PATH` args correctly, or `add_cdi_device()` in `run.rs` is not wiring the
+parsed pairs into `with_dev_symlink()`.
+
 ### `test_bind_mount_into_dev`
 **Requires:** root, rootfs
 

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -110,6 +110,44 @@ pub struct CdiHook {
     pub env: Vec<String>,
 }
 
+impl CdiHook {
+    /// If this hook is `nvidia-ctk hook create-symlinks` (the hook
+    /// `nvidia-ctk cdi generate` embeds to recreate the driver's SONAME
+    /// symlink chain, e.g. `libnvidia-ml.so.580.173.02` ->
+    /// `libnvidia-ml.so.1` -> `libnvidia-ml.so`), parse its `--link
+    /// TARGET::LINK_PATH` args into `(target, link_path)` pairs — `target`
+    /// is the (relative) symlink target, `link_path` is the absolute path
+    /// (inside the container) where the symlink should be created,
+    /// matching `ln -sf TARGET LINK_PATH` semantics.
+    ///
+    /// Returns `None` for any other hook — Pelagos does not execute
+    /// arbitrary CDI hook binaries (see module docs for why: by the time a
+    /// createContainer-equivalent point is reached, pelagos has already
+    /// chrooted, so a host-side hook binary like `nvidia-ctk` would not be
+    /// found inside the container's rootfs). `create-symlinks` is handled
+    /// as a native built-in instead, since its behavior is fully described
+    /// by these args and needs no external binary.
+    pub fn nvidia_create_symlinks_pairs(&self) -> Option<Vec<(String, String)>> {
+        let is_create_symlinks =
+            self.path.ends_with("nvidia-ctk") && self.args.iter().any(|a| a == "create-symlinks");
+        if !is_create_symlinks {
+            return None;
+        }
+        let mut pairs = Vec::new();
+        let mut iter = self.args.iter();
+        while let Some(arg) = iter.next() {
+            if arg == "--link" {
+                if let Some(spec) = iter.next() {
+                    if let Some((target, link_path)) = spec.split_once("::") {
+                        pairs.push((target.to_string(), link_path.to_string()));
+                    }
+                }
+            }
+        }
+        Some(pairs)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CdiDevice {
     pub name: String,
@@ -371,5 +409,49 @@ devices:
         ann.insert("other.annotation".to_string(), "ignored".to_string());
         let names = devices_from_annotations(&ann);
         assert_eq!(names, vec!["vendor.com/gpu=0", "vendor.com/gpu=1"]);
+    }
+
+    #[test]
+    fn nvidia_create_symlinks_parses_link_pairs() {
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/nvidia-ctk".to_string(),
+            args: vec![
+                "nvidia-ctk".to_string(),
+                "hook".to_string(),
+                "create-symlinks".to_string(),
+                "--link".to_string(),
+                "libnvidia-ml.so.580.173.02::/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1"
+                    .to_string(),
+                "--link".to_string(),
+                "libnvidia-ml.so.1::/usr/lib/aarch64-linux-gnu/libnvidia-ml.so".to_string(),
+            ],
+            env: vec![],
+        };
+        let pairs = hook.nvidia_create_symlinks_pairs().unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                (
+                    "libnvidia-ml.so.580.173.02".to_string(),
+                    "/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1".to_string()
+                ),
+                (
+                    "libnvidia-ml.so.1".to_string(),
+                    "/usr/lib/aarch64-linux-gnu/libnvidia-ml.so".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn nvidia_create_symlinks_ignores_other_hooks() {
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/some-other-tool".to_string(),
+            args: vec!["some-other-tool".to_string(), "do-something".to_string()],
+            env: vec![],
+        };
+        assert!(hook.nvidia_create_symlinks_pairs().is_none());
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1389,13 +1389,30 @@ fn add_cdi_device(
             cmd = cmd.env(k, v);
         }
     }
-    if !edits.hooks.is_empty() {
-        log::warn!(
-            "CDI device '{}' defines {} hook(s); OCI lifecycle hooks are not yet \
-             supported on the `pelagos run` CLI path (only on the OCI bundle path) — ignoring",
-            qualified_name,
-            edits.hooks.len()
-        );
+    for hook in &edits.hooks {
+        match hook.nvidia_create_symlinks_pairs() {
+            Some(pairs) => {
+                for (target, link_path) in pairs {
+                    cmd = cmd.with_dev_symlink(link_path, target);
+                }
+            }
+            None => {
+                // Pelagos does not execute arbitrary CDI hook binaries on the CLI
+                // path — see CdiHook::nvidia_create_symlinks_pairs() for why
+                // (chroot already happened by the time a createContainer-equivalent
+                // point is reached, so a host-side binary wouldn't be found inside
+                // the container). create-symlinks is handled as a native built-in
+                // above; anything else is logged and skipped rather than silently
+                // pretending to have run it.
+                log::warn!(
+                    "CDI device '{}' defines a '{}' hook ({}) that pelagos does not \
+                     know how to execute natively on the `pelagos run` CLI path — ignoring",
+                    qualified_name,
+                    hook.hook_name,
+                    hook.path
+                );
+            }
+        }
     }
     Ok(cmd)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2263,6 +2263,102 @@ containerEdits:
         );
     }
 
+    /// test_cli_device_flag_cdi_create_symlinks_hook
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Regression test for #516. Reproduces the real NVIDIA CDI spec shape
+    /// (issue repro): a `mounts` entry for a versioned driver lib
+    /// (`libcditest.so.1.2.3`) plus a `createContainer` hook whose `args`
+    /// are literally `nvidia-ctk hook create-symlinks --link A::B --link C::D`
+    /// — the exact syntax `nvidia-ctk cdi generate` embeds to recreate the
+    /// SONAME symlink chain. Before this fix, `pelagos run` resolved the
+    /// mount but silently skipped the hook (logged a warning), leaving the
+    /// unversioned symlink name missing — mirroring the real bug where
+    /// `nvidia-smi` failed with "couldn't find libnvidia-ml.so" despite the
+    /// versioned file being present. Asserts the two-hop symlink chain
+    /// (`libcditest.so` -> `libcditest.so.1` -> `libcditest.so.1.2.3`)
+    /// resolves to the mounted file's actual contents when read through the
+    /// unversioned name, the same way `dlopen("libnvidia-ml.so")` would.
+    ///
+    /// Failure indicates `CdiHook::nvidia_create_symlinks_pairs()` in
+    /// `cdi.rs` is not parsing `--link TARGET::LINK_PATH` args correctly, or
+    /// `add_cdi_device()` in `run.rs` is not wiring the parsed pairs into
+    /// `with_dev_symlink()`.
+    #[test]
+    fn test_cli_device_flag_cdi_create_symlinks_hook() {
+        if !is_root() {
+            eprintln!("Skipping test_cli_device_flag_cdi_create_symlinks_hook: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_cli_device_flag_cdi_create_symlinks_hook: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let cdi_dir = tempfile::tempdir().expect("tempdir");
+        let driver_dir = tempfile::tempdir().expect("tempdir");
+        let driver_path = driver_dir.path().join("libcditest.so.1.2.3");
+        std::fs::write(&driver_path, "CDI_SYMLINK_HOOK_CONTENTS").unwrap();
+
+        let spec = format!(
+            r#"
+cdiVersion: "0.6.0"
+kind: "test.pelagos.dev/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      mounts:
+        - hostPath: "{driver}"
+          containerPath: "/opt/cdi-hooks/libcditest.so.1.2.3"
+          options: ["ro", "bind"]
+      hooks:
+        - hookName: createContainer
+          path: /usr/bin/nvidia-ctk
+          args:
+            - nvidia-ctk
+            - hook
+            - create-symlinks
+            - --link
+            - libcditest.so.1.2.3::/opt/cdi-hooks/libcditest.so.1
+            - --link
+            - libcditest.so.1::/opt/cdi-hooks/libcditest.so
+"#,
+            driver = driver_path.display()
+        );
+        std::fs::write(cdi_dir.path().join("vendor.yaml"), spec).unwrap();
+
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .env("PELAGOS_CDI_SPEC_DIRS", cdi_dir.path())
+            .args([
+                "run",
+                "--network",
+                "loopback",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--device",
+                "test.pelagos.dev/gpu=0",
+                "/bin/sh",
+                "-c",
+                "ls -la /opt/cdi-hooks/; cat /opt/cdi-hooks/libcditest.so 2>&1",
+            ])
+            .output()
+            .expect("pelagos run --device <cdi with create-symlinks hook>");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stdout.contains("CDI_SYMLINK_HOOK_CONTENTS"),
+            "reading through the unversioned symlink (libcditest.so -> \
+             libcditest.so.1 -> libcditest.so.1.2.3) did not return the mounted \
+             file's contents — create-symlinks hook was not executed. \
+             stdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+    }
+
     /// test_bind_mount_into_dev
     ///
     /// Requires: root, rootfs.


### PR DESCRIPTION
## Summary
The CDI `hooks` array was resolved but silently skipped-and-warned on the `pelagos run --device <cdi>` path (#513). NVIDIA's generated CDI spec relies on exactly this — a `createContainer` hook (`nvidia-ctk hook create-symlinks --link SRC::DST`) that recreates the driver's SONAME symlink chain. Without it, the versioned `.so` mounts correctly but `nvidia-smi`/CUDA fail at `dlopen` time because the unversioned name never exists. Reported via the agent-coordinator blackboard by the k3s-experiments agent, confirmed on the DGX Spark (spark-0d93) after upgrading to v0.65.83 — the last blocker for k3s-experiments#16.

- `src/cdi.rs`: `CdiHook::nvidia_create_symlinks_pairs()` recognizes this specific, well-known hook (path ends in `nvidia-ctk`, args contain `create-symlinks`) and parses `--link TARGET::LINK_PATH` args into pairs. Returns `None` for anything else — Pelagos doesn't execute arbitrary CDI hook binaries, since by the time a createContainer-equivalent point is reached the container is already chrooted, so a host-side binary wouldn't be found inside the container's rootfs. `create-symlinks` is handled as a native built-in instead.
- `src/cli/run.rs`: `add_cdi_device()` wires the parsed pairs into `cmd.with_dev_symlink()` — an existing, already-correct mechanism (Vec-accumulating, so it composes across multiple `--device` flags, and already runs at exactly the right pre-exec point: post-chroot, post-device-nodes). Unrecognized hooks are still logged and skipped, not silently pretended-done.

Closes #516.

## Test plan
- [x] New integration test `test_cli_device_flag_cdi_create_symlinks_hook`: reproduces the exact CDI spec shape from the issue (versioned mount + create-symlinks hook with two `--link` pairs), asserts reading through the two-hop unversioned symlink chain returns the mounted file's contents (the same way `dlopen()` would resolve it)
- [x] 2 new unit tests in `cdi.rs` for `--link` arg parsing (recognized + ignored-for-other-hooks)
- [x] `filesystem::*` (15 tests, incl. both CDI CLI tests), `dev::*` (5 tests), `oci_lifecycle::*` (29 tests, incl. #512's CDI test) all pass — no regressions
- [x] Full `cargo test --lib` (405 tests) passes
- [x] `cargo fmt --check` clean; `cargo clippy --lib -- -D warnings` clean
- [x] `docs/INTEGRATION_TESTS.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)