### PR TITLE
fix(cdi): recognize create-symlinks hook by args, not binary path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.83"
+version = "0.65.84"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -448,9 +448,25 @@ libnvidia-ml.so" despite the versioned file being present. Asserts the two-hop s
 chain (`libcditest.so` -> `libcditest.so.1` -> `libcditest.so.1.2.3`) resolves to the
 mounted file's actual contents when read through the unversioned name, the same way
 `dlopen("libnvidia-ml.so")` would. Failure indicates
-`CdiHook::nvidia_create_symlinks_pairs()` in `cdi.rs` is not parsing `--link
+`CdiHook::create_symlinks_pairs()` in `cdi.rs` is not parsing `--link
 TARGET::LINK_PATH` args correctly, or `add_cdi_device()` in `run.rs` is not wiring the
 parsed pairs into `with_dev_symlink()`.
+
+### `test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary`
+**Requires:** root, rootfs
+
+Regression test for #518. Identical to `test_cli_device_flag_cdi_create_symlinks_hook`
+except the hook's `path`/`args[0]` is `nvidia-cdi-hook` instead of `nvidia-ctk hook` —
+the exact real-world shape from #518's repro on nvidia-container-toolkit 1.17+, which
+ships the same `create-symlinks --link A::B` convention under a different binary.
+Before this fix, `CdiHook::create_symlinks_pairs()` pattern-matched on
+`path == ".../nvidia-ctk"` and silently skipped any other binary name, even though the
+args fully describe the same operation — this was the actual root cause of #518 (the
+fix for #516 only worked for the older toolkit's binary name). Uses a distinct
+container path (`/opt/cdi-hooks2/`) from the sibling `nvidia-ctk` test to avoid
+cross-test artifact collisions on the shared, non-ephemeral `alpine-rootfs`. Failure
+indicates `create_symlinks_pairs()` regressed back to checking `path` / the invoking
+binary's name instead of the `args` shape alone.
 
 ### `test_bind_mount_into_dev`
 **Requires:** root, rootfs

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -111,26 +111,34 @@ pub struct CdiHook {
 }
 
 impl CdiHook {
-    /// If this hook is `nvidia-ctk hook create-symlinks` (the hook
-    /// `nvidia-ctk cdi generate` embeds to recreate the driver's SONAME
-    /// symlink chain, e.g. `libnvidia-ml.so.580.173.02` ->
-    /// `libnvidia-ml.so.1` -> `libnvidia-ml.so`), parse its `--link
-    /// TARGET::LINK_PATH` args into `(target, link_path)` pairs — `target`
-    /// is the (relative) symlink target, `link_path` is the absolute path
-    /// (inside the container) where the symlink should be created,
-    /// matching `ln -sf TARGET LINK_PATH` semantics.
+    /// If this hook's `args` invoke a `create-symlinks` subcommand with
+    /// `--link TARGET::LINK_PATH` pairs — the convention `nvidia-ctk cdi
+    /// generate` embeds to recreate the driver's SONAME symlink chain, e.g.
+    /// `libnvidia-ml.so.580.173.02` -> `libnvidia-ml.so.1` ->
+    /// `libnvidia-ml.so` — parse those pairs out. `target` is the (relative)
+    /// symlink target, `link_path` is the absolute path (inside the
+    /// container) where the symlink should be created, matching `ln -sf
+    /// TARGET LINK_PATH` semantics.
     ///
-    /// Returns `None` for any other hook — Pelagos does not execute
-    /// arbitrary CDI hook binaries (see module docs for why: by the time a
-    /// createContainer-equivalent point is reached, pelagos has already
-    /// chrooted, so a host-side hook binary like `nvidia-ctk` would not be
-    /// found inside the container's rootfs). `create-symlinks` is handled
-    /// as a native built-in instead, since its behavior is fully described
-    /// by these args and needs no external binary.
-    pub fn nvidia_create_symlinks_pairs(&self) -> Option<Vec<(String, String)>> {
-        let is_create_symlinks =
-            self.path.ends_with("nvidia-ctk") && self.args.iter().any(|a| a == "create-symlinks");
-        if !is_create_symlinks {
+    /// Deliberately does NOT check `path` / the invoking binary's name.
+    /// nvidia-container-toolkit has shipped this exact `create-symlinks
+    /// --link A::B` convention under at least two different binaries
+    /// (`nvidia-ctk hook create-symlinks` on older toolkit versions,
+    /// `nvidia-cdi-hook create-symlinks` on 1.17+) — see #518, where
+    /// pattern-matching on `path == ".../nvidia-ctk"` silently broke on a
+    /// system using the newer binary. The `--link` args fully describe the
+    /// hook's behavior regardless of what its binary happens to be called,
+    /// so recognition is keyed on the args shape alone.
+    ///
+    /// Returns `None` for any hook that isn't this convention — Pelagos does
+    /// not execute arbitrary CDI hook binaries on the CLI path (see module
+    /// docs for why: by the time a createContainer-equivalent point is
+    /// reached, pelagos has already chrooted, so a host-side hook binary
+    /// would not be found inside the container's rootfs). `create-symlinks`
+    /// is handled as a native built-in instead, since its behavior is fully
+    /// described by its own args and needs no external binary.
+    pub fn create_symlinks_pairs(&self) -> Option<Vec<(String, String)>> {
+        if !self.args.iter().any(|a| a == "create-symlinks") {
             return None;
         }
         let mut pairs = Vec::new();
@@ -428,7 +436,43 @@ devices:
             ],
             env: vec![],
         };
-        let pairs = hook.nvidia_create_symlinks_pairs().unwrap();
+        let pairs = hook.create_symlinks_pairs().unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                (
+                    "libnvidia-ml.so.580.173.02".to_string(),
+                    "/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1".to_string()
+                ),
+                (
+                    "libnvidia-ml.so.1".to_string(),
+                    "/usr/lib/aarch64-linux-gnu/libnvidia-ml.so".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn create_symlinks_recognized_regardless_of_binary_name() {
+        // Regression test for #518: nvidia-container-toolkit 1.17+ ships this
+        // exact create-symlinks/--link convention under a different binary,
+        // `nvidia-cdi-hook`, not `nvidia-ctk`. Recognition must not depend on
+        // `path`.
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/nvidia-cdi-hook".to_string(),
+            args: vec![
+                "nvidia-cdi-hook".to_string(),
+                "create-symlinks".to_string(),
+                "--link".to_string(),
+                "libnvidia-ml.so.580.173.02::/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1"
+                    .to_string(),
+                "--link".to_string(),
+                "libnvidia-ml.so.1::/usr/lib/aarch64-linux-gnu/libnvidia-ml.so".to_string(),
+            ],
+            env: vec![],
+        };
+        let pairs = hook.create_symlinks_pairs().unwrap();
         assert_eq!(
             pairs,
             vec![
@@ -452,6 +496,6 @@ devices:
             args: vec!["some-other-tool".to_string(), "do-something".to_string()],
             env: vec![],
         };
-        assert!(hook.nvidia_create_symlinks_pairs().is_none());
+        assert!(hook.create_symlinks_pairs().is_none());
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1390,7 +1390,7 @@ fn add_cdi_device(
         }
     }
     for hook in &edits.hooks {
-        match hook.nvidia_create_symlinks_pairs() {
+        match hook.create_symlinks_pairs() {
             Some(pairs) => {
                 for (target, link_path) in pairs {
                     cmd = cmd.with_dev_symlink(link_path, target);
@@ -1398,7 +1398,7 @@ fn add_cdi_device(
             }
             None => {
                 // Pelagos does not execute arbitrary CDI hook binaries on the CLI
-                // path — see CdiHook::nvidia_create_symlinks_pairs() for why
+                // path — see CdiHook::create_symlinks_pairs() for why
                 // (chroot already happened by the time a createContainer-equivalent
                 // point is reached, so a host-side binary wouldn't be found inside
                 // the container). create-symlinks is handled as a native built-in

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2181,7 +2181,15 @@ mod filesystem {
     /// Failure indicates `add_cdi_device()` in `run.rs` is not resolving CDI
     /// device names passed via `--device`, or not merging deviceNodes/mounts/
     /// env into the `Command` before spawn.
+    ///
+    /// `#[serial(cdi_rootfs)]`: this and the other `--device <cdi>` CLI tests
+    /// all run `pelagos run --rootfs <shared alpine-rootfs>` directly
+    /// (non-ephemeral, no overlay) — running them concurrently races on the
+    /// same physical directory tree and produces spurious "Failed to spawn
+    /// process: No such file or directory" failures unrelated to CDI logic
+    /// (confirmed via `--test-threads=1`, see #518 session notes).
     #[test]
+    #[serial(cdi_rootfs)]
     fn test_cli_device_flag_cdi_resolution() {
         if !is_root() {
             eprintln!("Skipping test_cli_device_flag_cdi_resolution: requires root");
@@ -2281,11 +2289,12 @@ containerEdits:
     /// resolves to the mounted file's actual contents when read through the
     /// unversioned name, the same way `dlopen("libnvidia-ml.so")` would.
     ///
-    /// Failure indicates `CdiHook::nvidia_create_symlinks_pairs()` in
+    /// Failure indicates `CdiHook::create_symlinks_pairs()` in
     /// `cdi.rs` is not parsing `--link TARGET::LINK_PATH` args correctly, or
     /// `add_cdi_device()` in `run.rs` is not wiring the parsed pairs into
     /// `with_dev_symlink()`.
     #[test]
+    #[serial(cdi_rootfs)]
     fn test_cli_device_flag_cdi_create_symlinks_hook() {
         if !is_root() {
             eprintln!("Skipping test_cli_device_flag_cdi_create_symlinks_hook: requires root");
@@ -2354,6 +2363,100 @@ devices:
              libcditest.so.1 -> libcditest.so.1.2.3) did not return the mounted \
              file's contents — create-symlinks hook was not executed. \
              stdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+    }
+
+    /// test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Regression test for #518. Identical to
+    /// `test_cli_device_flag_cdi_create_symlinks_hook` except the hook's
+    /// `path`/`args[0]` is `nvidia-cdi-hook` instead of `nvidia-ctk hook` —
+    /// the exact real-world shape from #518's repro on nvidia-container-toolkit
+    /// 1.17+, which ships the same `create-symlinks --link A::B` convention
+    /// under a different binary. Before this fix, `create_symlinks_pairs()`
+    /// pattern-matched on `path == ".../nvidia-ctk"` and silently skipped any
+    /// other binary name, even though the args fully describe the same
+    /// operation. Uses a distinct container path
+    /// (`/opt/cdi-hooks2/`) from the sibling `nvidia-ctk` test to avoid
+    /// cross-test artifact collisions on the shared, non-ephemeral
+    /// `alpine-rootfs` (see #516 memory notes on this gotcha).
+    ///
+    /// Failure indicates `CdiHook::create_symlinks_pairs()` regressed back to
+    /// checking `path` / the invoking binary's name.
+    #[test]
+    #[serial(cdi_rootfs)]
+    fn test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary: requires root"
+            );
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let cdi_dir = tempfile::tempdir().expect("tempdir");
+        let driver_dir = tempfile::tempdir().expect("tempdir");
+        let driver_path = driver_dir.path().join("libcditest.so.1.2.3");
+        std::fs::write(&driver_path, "CDI_HOOK_BINARY_CONTENTS").unwrap();
+
+        let spec = format!(
+            r#"
+cdiVersion: "0.6.0"
+kind: "test.pelagos.dev/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      mounts:
+        - hostPath: "{driver}"
+          containerPath: "/opt/cdi-hooks2/libcditest.so.1.2.3"
+          options: ["ro", "bind"]
+      hooks:
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - create-symlinks
+            - --link
+            - libcditest.so.1.2.3::/opt/cdi-hooks2/libcditest.so.1
+            - --link
+            - libcditest.so.1::/opt/cdi-hooks2/libcditest.so
+"#,
+            driver = driver_path.display()
+        );
+        std::fs::write(cdi_dir.path().join("vendor.yaml"), spec).unwrap();
+
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .env("PELAGOS_CDI_SPEC_DIRS", cdi_dir.path())
+            .args([
+                "run",
+                "--network",
+                "loopback",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--device",
+                "test.pelagos.dev/gpu=0",
+                "/bin/sh",
+                "-c",
+                "ls -la /opt/cdi-hooks2/; cat /opt/cdi-hooks2/libcditest.so 2>&1",
+            ])
+            .output()
+            .expect("pelagos run --device <cdi with nvidia-cdi-hook create-symlinks>");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stdout.contains("CDI_HOOK_BINARY_CONTENTS"),
+            "reading through the unversioned symlink did not return the mounted \
+             file's contents — create-symlinks hook was not executed for the \
+             nvidia-cdi-hook binary shape. stdout:\n{}\nstderr:\n{}",
             stdout,
             stderr
         );


### PR DESCRIPTION
## Summary
Third round on the same underlying gap (#512 → #513 → #516 → this). #516/PR #517's `create-symlinks` hook recognition gated on `hook.path` ending in `nvidia-ctk`. `nvidia-container-toolkit` 1.17+ ships the identical `create-symlinks --link A::B` convention under a different binary, `/usr/bin/nvidia-cdi-hook` — confirmed on spark-0d93 running toolkit 1.19.1, reproducing the exact original #516 symptom (`nvidia-smi` "couldn't find libnvidia-ml.so"). Reported via the agent-coordinator blackboard by the k3s-experiments agent with a full repro (debug log line + CDI spec excerpt).

- `src/cdi.rs`: `CdiHook::create_symlinks_pairs()` (renamed from `nvidia_create_symlinks_pairs`) now recognizes the hook purely from its `args` shape (`create-symlinks` + `--link TARGET::LINK_PATH` pairs) — no `path`/binary-name check at all. The issue itself made the right call here: the args fully describe the operation regardless of what the binary is called, so recognition shouldn't depend on it.
- Deliberately did **not** implement fully-generic arbitrary-hook execution (exec whatever `path`+`args` verbatim, as the issue also floats as an option). That needs pre-chroot host-side execution with a synthesized OCI state on stdin — the protocol these hook binaries actually expect — which is a materially bigger, riskier change I can't fully validate without real GPU hardware to test against. The args-driven native handler covers the actual, confirmed, only-ever-reported need without that risk.

## Test plan
- [x] New integration test `test_cli_device_flag_cdi_create_symlinks_hook_nvidia_cdi_hook_binary`: reproduces #518's exact CDI spec shape (`nvidia-cdi-hook` binary, same `--link` args)
- [x] New unit test `create_symlinks_recognized_regardless_of_binary_name` in `cdi.rs`
- [x] Found and fixed a related test-isolation bug while adding these: all three `--device <cdi>` CLI integration tests run `pelagos run --rootfs <shared alpine-rootfs>` directly and were racing each other when run concurrently (spurious "Failed to spawn process" failures, confirmed via `--test-threads=1`) — added `#[serial(cdi_rootfs)]` to all three. (A broader pre-existing race across other `--rootfs`-direct tests in `filesystem::` was found but is out of scope here — logged in session memory for a future dedicated cleanup.)
- [x] `filesystem::*` (16 tests, all 3 CDI tests together), `dev::*` (5 tests), `oci_lifecycle::*` (29 tests) all pass
- [x] Full `cargo test --lib` (406 tests) passes
- [x] `cargo fmt --check` clean; `cargo clippy --lib -- -D warnings` clean
- [x] `docs/INTEGRATION_TESTS.md` updated

Closes #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)