### PR TITLE
fix(container): prefer fuse-overlayfs for single-uid rootless overlay (#522)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.85"
+version = "0.65.86"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -2057,6 +2057,23 @@ staging directories with mode=0 as a security measure, and overlayfs copy-up of
 those directories fails unless `fuse-overlayfs` has `CAP_DAC_OVERRIDE` (which it
 gets when running as uid 0 inside its user namespace).
 
+### `test_rootless_single_uid_overlay_copy_up_avoids_eoverflow`
+**Requires:** non-root + rootfs + `fuse-overlayfs` on PATH
+
+Regression test for #522. Spawns a rootless container with an explicit
+single-UID/GID map (no subordinate range — the plain-rootless fallback) over
+an overlay whose lower dir (the shared alpine-rootfs) contains root-owned
+content, and runs `chmod 644 /etc/passwd && echo ok` to force a copy-up of a
+file whose owner is unmapped in the container's user namespace. Asserts the
+container exits 0 and stdout contains `ok`.
+
+Failure indicates overlay backend selection is again picking native kernel
+overlayfs for the single-id-map case: native overlayfs's copy-up path cannot
+represent an unmapped owner and fails with EOVERFLOW, which is exactly what
+CDI GPU passthrough hit on real (non-subuid-delegated) rootless hosts running
+multi-owner base images. The fix prefers fuse-overlayfs (`squash_to_uid/gid=0`)
+whenever only a single-id map is available.
+
 Fixed across multiple commits (issue #195):
 - Removed a stale CVE-2023-0386 fast-path that incorrectly blocked native overlayfs
 - Pre-seeded `resolv.conf`/`/etc/hosts` into overlay upper dir to avoid bind-mount

--- a/src/container.rs
+++ b/src/container.rs
@@ -3692,7 +3692,18 @@ impl Command {
         // None in all other cases.
         let fuse_overlay_opts_c: Option<std::ffi::CString>;
         if is_rootless && self.overlay.is_some() {
-            if native_rootless_overlay_supported() {
+            // #522: with only a single 1:1 uid/gid map (no subordinate range —
+            // `use_id_helpers` false), any lower-layer file NOT owned by our own
+            // uid/gid is unrepresentable in the user namespace. Native kernel
+            // overlayfs's copy-up path fails to preserve such unmapped ownership
+            // and returns EOVERFLOW (same mechanism already documented for the
+            // nested-build case, #432 — just triggered here by ordinary
+            // multi-owner image content, e.g. apt-installed files in real base
+            // images). fuse-overlayfs's squash_to_uid/gid=0 presents every
+            // lower-layer file as owned by 0, sidestepping the mapping problem
+            // entirely, so prefer it whenever we lack a real subordinate range.
+            let single_id_map = !use_id_helpers;
+            if !single_id_map && native_rootless_overlay_supported() {
                 log::debug!("rootless overlay: using native overlay+userxattr");
                 use_fuse_overlay = false;
                 fuse_overlay_opts_c = None;
@@ -3713,6 +3724,15 @@ impl Command {
                 } else {
                     fuse_overlay_opts_c = None;
                 }
+            } else if native_rootless_overlay_supported() {
+                log::warn!(
+                    "rootless overlay: no subordinate uid/gid range and fuse-overlayfs is \
+                     unavailable — falling back to native overlay+userxattr; files owned by \
+                     uids/gids other than ours in image layers may fail with EOVERFLOW on \
+                     copy-up (#522); install fuse-overlayfs for full compatibility"
+                );
+                use_fuse_overlay = false;
+                fuse_overlay_opts_c = None;
             } else {
                 return Err(Error::Io(io::Error::other(
                     "rootless overlay requires kernel 5.11+ or fuse-overlayfs; \
@@ -7091,7 +7111,18 @@ impl Command {
         // None in all other cases.
         let fuse_overlay_opts_c: Option<std::ffi::CString>;
         if is_rootless && self.overlay.is_some() {
-            if native_rootless_overlay_supported() {
+            // #522: with only a single 1:1 uid/gid map (no subordinate range —
+            // `use_id_helpers` false), any lower-layer file NOT owned by our own
+            // uid/gid is unrepresentable in the user namespace. Native kernel
+            // overlayfs's copy-up path fails to preserve such unmapped ownership
+            // and returns EOVERFLOW (same mechanism already documented for the
+            // nested-build case, #432 — just triggered here by ordinary
+            // multi-owner image content, e.g. apt-installed files in real base
+            // images). fuse-overlayfs's squash_to_uid/gid=0 presents every
+            // lower-layer file as owned by 0, sidestepping the mapping problem
+            // entirely, so prefer it whenever we lack a real subordinate range.
+            let single_id_map = !use_id_helpers;
+            if !single_id_map && native_rootless_overlay_supported() {
                 log::debug!("rootless overlay: using native overlay+userxattr");
                 use_fuse_overlay = false;
                 fuse_overlay_opts_c = None;
@@ -7112,6 +7143,15 @@ impl Command {
                 } else {
                     fuse_overlay_opts_c = None;
                 }
+            } else if native_rootless_overlay_supported() {
+                log::warn!(
+                    "rootless overlay: no subordinate uid/gid range and fuse-overlayfs is \
+                     unavailable — falling back to native overlay+userxattr; files owned by \
+                     uids/gids other than ours in image layers may fail with EOVERFLOW on \
+                     copy-up (#522); install fuse-overlayfs for full compatibility"
+                );
+                use_fuse_overlay = false;
+                fuse_overlay_opts_c = None;
             } else {
                 return Err(Error::Io(io::Error::other(
                     "rootless overlay requires kernel 5.11+ or fuse-overlayfs; \

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12246,6 +12246,93 @@ mod rootless_idmap {
             out.trim()
         );
     }
+
+    /// test_rootless_single_uid_overlay_copy_up_avoids_eoverflow
+    ///
+    /// Rootless (non-root), requires `fuse-overlayfs` on PATH and the shared
+    /// alpine-rootfs.
+    ///
+    /// Regression test for #522: with only a single 1:1 uid/gid map (no
+    /// `/etc/subuid`/`/etc/subgid` delegation — the plain-rootless fallback,
+    /// same shape as `test_rootless_single_uid_fallback` above), writing
+    /// through an overlay to a lower-layer file NOT owned by our own uid/gid
+    /// (`/etc/passwd`, owned by root:root on the shared rootfs, almost always
+    /// different from the non-root uid running this test) forces a copy-up of
+    /// an unmapped owner. Before #522's fix, overlay backend selection only
+    /// considered kernel/btrfs support and would happily pick native
+    /// overlay+userxattr for this case, which fails the copy-up with
+    /// EOVERFLOW. The fix prefers fuse-overlayfs (squash_to_uid/gid=0) when
+    /// only a single-id map is available, so the copy-up (and hence the
+    /// container) now succeeds.
+    ///
+    /// Failure indicates the single-id-map / native-overlay EOVERFLOW
+    /// regression from #522 is back.
+    #[test]
+    fn test_rootless_single_uid_overlay_copy_up_avoids_eoverflow() {
+        if is_root() {
+            eprintln!("Skipping: must run as non-root");
+            return;
+        }
+        let fuse_available = std::process::Command::new("fuse-overlayfs")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok();
+        if !fuse_available {
+            eprintln!("Skipping: fuse-overlayfs not on PATH");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let upper = tmp.path().join("upper");
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&upper).expect("mkdir upper");
+        std::fs::create_dir_all(&work).expect("mkdir work");
+
+        // Explicit single-UID map (bypassing subuid auto-config) over an
+        // overlay whose lower dir (the chroot rootfs) has root-owned content
+        // — forces a copy-up of a file with an unmapped owner.
+        let mut child = Command::new("/bin/ash")
+            .args(["-c", "chmod 644 /etc/passwd && echo ok"])
+            .env("PATH", ALPINE_PATH)
+            .with_chroot(&rootfs)
+            .with_overlay(&upper, &work)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_uid_maps(&[UidMap {
+                inside: 0,
+                outside: unsafe { libc::getuid() },
+                count: 1,
+            }])
+            .with_gid_maps(&[GidMap {
+                inside: 0,
+                outside: unsafe { libc::getgid() },
+                count: 1,
+            }])
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("rootless single-uid overlay spawn failed");
+
+        let (status, stdout, stderr) = child.wait_with_output().expect("wait failed");
+        let out = String::from_utf8_lossy(&stdout);
+        let err = String::from_utf8_lossy(&stderr);
+        assert!(
+            status.success(),
+            "copy-up of unmapped-owner file failed under single-uid rootless overlay \
+             (#522 regression); stdout={out}, stderr={err}"
+        );
+        assert_eq!(
+            out.trim(),
+            "ok",
+            "expected 'ok' from chmod test, got: {}",
+            out.trim()
+        );
+    }
 }
 
 // ── Build instruction tests (ENTRYPOINT, LABEL, USER, cache) ────────────────


### PR DESCRIPTION
## Summary
- Fixes the EOVERFLOW half of #522: `pelagos run --device ...` (#520's fixes, #518/#521) only worked under root/privileged runs. Under **true rootless** (plain non-root user, no `/etc/subuid`/`/etc/subgid` delegation), the container falls back to a single 1:1 uid/gid map — and overlay backend selection (`native_rootless_overlay_supported()`) had no awareness of that, so it still picked native kernel overlayfs.
- Native overlayfs's copy-up path cannot represent a lower-layer file owned by an uid/gid unmapped in the container's user namespace and fails with `EOVERFLOW` — the exact mechanism already documented for the nested-build case (#432, "Fallback map" comment in `Command::spawn`), just never extended to the plain-rootless single-id-map case. Real base images (the reported repro used `nvcr.io/nvidia/cuda:*-ubuntu*`) commonly ship apt-installed files owned by non-root uids, so this triggers reliably.
- Fix: when rootless and only a single-id map is available (`!use_id_helpers`), prefer `fuse-overlayfs` — its `squash_to_uid=0,squash_to_gid=0` presents every lower-layer file as owned by 0, sidestepping the mapping problem entirely. Falls back to native overlay (unchanged behavior) with a `warn!` if fuse-overlayfs isn't installed. Subuid-delegated rootless (`use_id_helpers = true`) is untouched. Applied at both duplicated decision sites (`spawn()` and `spawn_interactive()`).

## On the hook-warning half of #522
#519 (merged, v0.65.85+) already made `create-symlinks` hook recognition args-driven, not gated on root vs rootless — it runs identically either way. The "does not know how to execute natively... ignoring" warning is non-fatal and most likely fires for a genuinely different, unhandled CDI hook in the same spec (e.g. `update-ldcache`) rather than a #518/#519 regression. No code change here for that half — flagging it for the k3s agent's next retest to confirm.

Plan posted to #522 before implementation: https://github.com/pelagos-containers/pelagos/issues/522#issuecomment-5288504608

## Test plan
- [x] New regression test `rootless_idmap::test_rootless_single_uid_overlay_copy_up_avoids_eoverflow`: explicit single-uid/gid map + overlay over the shared alpine-rootfs, forces a copy-up of a root-owned `/etc/passwd` via `chmod`. Confirmed this reproduces against the pre-fix code (fails) and passes with the fix.
- [x] `cargo test --lib` — 406 passed
- [x] Ran `rootless_idmap::*` as non-root (pre-existing tests in this environment fail with unrelated `EPERM` at spawn — confirmed on `main` too, not a regression from this change; the new test and `test_rootless_overlay_mode0_mkdir_succeeds` both pass)
- [x] `cargo fmt --check` / `cargo clippy --lib -- -D warnings` clean
- [x] Documented in `docs/INTEGRATION_TESTS.md`

**Still open:** confirmation from the k3s agent's retest on spark-0d93 that this actually resolves the reported EOVERFLOW on real hardware — no GPU/aarch64 available in this dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)