### PR TITLE
fix(cdi): execute update-ldcache CDI hook natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.87"
+version = "0.65.89"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -468,6 +468,25 @@ cross-test artifact collisions on the shared, non-ephemeral `alpine-rootfs`. Fai
 indicates `create_symlinks_pairs()` regressed back to checking `path` / the invoking
 binary's name instead of the `args` shape alone.
 
+### `test_cli_device_flag_cdi_update_ldcache_hook`
+**Requires:** root, rootfs
+
+Regression test for #529. The same real-world CDI spec shape as
+`test_cli_device_flag_cdi_create_symlinks_hook` ships a *second* `createContainer`
+hook right alongside `create-symlinks`: `update-ldcache --folder DIR`, which refreshes
+the dynamic linker cache so libraries placed by `create-symlinks` are visible to
+dlopen-based resolution (Triton, PyTorch's inductor backend) rather than just a
+hardcoded search path (which is why `nvidia-smi` worked but `vllm serve` didn't).
+Before this fix, `pelagos run` recognized `create-symlinks` but silently skipped
+`update-ldcache` (logged a warning) — libraries were correctly placed and symlinked
+but never registered in `/etc/ld.so.cache`. Since the test rootfs has no real
+`ldconfig` (musl/Alpine's dynamic linker doesn't use an ld.so.cache), this
+bind-mounts a fake `ldconfig` shell script to `/sbin/ldconfig` that records its
+invocation args to a host-visible marker file, and asserts it was invoked with
+exactly the hook's `--folder` directory. Failure indicates
+`CdiHook::update_ldcache_folder()` in `cdi.rs` is not parsing the `--folder` arg, or
+`with_ldconfig_folder()` / `add_cdi_device()` are not wiring it through to pre_exec.
+
 ### `test_bind_mount_into_dev`
 **Requires:** root, rootfs
 

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -154,6 +154,31 @@ impl CdiHook {
         }
         Some(pairs)
     }
+
+    /// If this hook's `args` invoke an `update-ldcache` subcommand with a
+    /// `--folder DIR` argument — the convention `nvidia-ctk cdi generate`
+    /// embeds to refresh the dynamic linker cache for a directory of driver
+    /// libraries dropped in alongside the `create-symlinks` hook above — return
+    /// that directory. See #529: without this, libraries resolved via the
+    /// ldconfig cache (Triton, PyTorch's inductor backend) aren't found even
+    /// though `create-symlinks` placed them correctly on disk.
+    ///
+    /// Same rationale as `create_symlinks_pairs()` for not checking `path`/the
+    /// invoking binary's name, and for being handled as a native built-in
+    /// (`ldconfig <folder>`, run inside the container's own mount namespace)
+    /// rather than executing the host's hook binary.
+    pub fn update_ldcache_folder(&self) -> Option<String> {
+        if !self.args.iter().any(|a| a == "update-ldcache") {
+            return None;
+        }
+        let mut iter = self.args.iter();
+        while let Some(arg) = iter.next() {
+            if arg == "--folder" {
+                return iter.next().cloned();
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -497,5 +522,51 @@ devices:
             env: vec![],
         };
         assert!(hook.create_symlinks_pairs().is_none());
+    }
+
+    #[test]
+    fn update_ldcache_parses_folder_arg() {
+        // Regression test for #529: the CDI spec's second createContainer hook,
+        // alongside create-symlinks, must also be recognized natively.
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/nvidia-cdi-hook".to_string(),
+            args: vec![
+                "nvidia-cdi-hook".to_string(),
+                "update-ldcache".to_string(),
+                "--folder".to_string(),
+                "/usr/lib/aarch64-linux-gnu".to_string(),
+            ],
+            env: vec![],
+        };
+        assert_eq!(
+            hook.update_ldcache_folder(),
+            Some("/usr/lib/aarch64-linux-gnu".to_string())
+        );
+    }
+
+    #[test]
+    fn update_ldcache_ignores_other_hooks() {
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/nvidia-cdi-hook".to_string(),
+            args: vec![
+                "nvidia-cdi-hook".to_string(),
+                "disable-device-node-modification".to_string(),
+            ],
+            env: vec![],
+        };
+        assert!(hook.update_ldcache_folder().is_none());
+    }
+
+    #[test]
+    fn update_ldcache_missing_folder_arg_returns_none() {
+        let hook = CdiHook {
+            hook_name: "createContainer".to_string(),
+            path: "/usr/bin/nvidia-cdi-hook".to_string(),
+            args: vec!["nvidia-cdi-hook".to_string(), "update-ldcache".to_string()],
+            env: vec![],
+        };
+        assert!(hook.update_ldcache_folder().is_none());
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1390,11 +1390,15 @@ fn add_cdi_device(
         }
     }
     for hook in &edits.hooks {
-        match hook.create_symlinks_pairs() {
-            Some(pairs) => {
-                for (target, link_path) in pairs {
-                    cmd = cmd.with_dev_symlink(link_path, target);
-                }
+        if let Some(pairs) = hook.create_symlinks_pairs() {
+            for (target, link_path) in pairs {
+                cmd = cmd.with_dev_symlink(link_path, target);
+            }
+            continue;
+        }
+        match hook.update_ldcache_folder() {
+            Some(folder) => {
+                cmd = cmd.with_ldconfig_folder(folder);
             }
             None => {
                 // Pelagos does not execute arbitrary CDI hook binaries on the CLI

--- a/src/container.rs
+++ b/src/container.rs
@@ -1583,6 +1583,8 @@ pub struct Command {
     // Symlinks to create inside /dev when it is a fresh tmpfs.
     // Each entry is (link_path, target) — created via symlink(2) in pre_exec.
     dev_symlinks: Vec<(PathBuf, PathBuf)>,
+    // Directories to run `ldconfig` against in pre_exec (CDI update-ldcache hook).
+    ldconfig_folders: Vec<PathBuf>,
     // Ambient capability numbers (0–40) to raise via PR_CAP_AMBIENT_RAISE in pre_exec.
     ambient_cap_numbers: Vec<u8>,
     // OOM score adjustment to write to /proc/self/oom_score_adj in pre_exec.
@@ -1735,6 +1737,7 @@ impl Command {
             additional_networks: Vec::new(),
             propagation_mounts: Vec::new(),
             dev_symlinks: Vec::new(),
+            ldconfig_folders: Vec::new(),
             ambient_cap_numbers: Vec::new(),
             oom_score_adj: None,
             additional_gids: Vec::new(),
@@ -3020,6 +3023,20 @@ impl Command {
         self
     }
 
+    /// Run `ldconfig <folder>` inside the container's mount namespace in pre_exec,
+    /// after chroot/pivot_root but before the user command execs.
+    ///
+    /// Mirrors the CDI `update-ldcache` hook (see `CdiHook::update_ldcache_folder()`):
+    /// driver libraries dropped into `folder` (e.g. by `create-symlinks`) are not
+    /// picked up by dlopen-based resolution — Triton, PyTorch's inductor backend,
+    /// and anything else that resolves via the ldconfig cache rather than a
+    /// hardcoded path — until `/etc/ld.so.cache` is regenerated to include them.
+    /// `ldconfig` is resolved from the container's own rootfs, not the host's.
+    pub fn with_ldconfig_folder(mut self, folder: impl Into<PathBuf>) -> Self {
+        self.ldconfig_folders.push(folder.into());
+        self
+    }
+
     /// Raise a capability in the ambient set (PR_CAP_AMBIENT_RAISE).
     ///
     /// `cap_num` is the kernel capability number (0 = CAP_CHOWN, 1 = CAP_DAC_OVERRIDE, …).
@@ -3535,6 +3552,7 @@ impl Command {
         let sysctl = self.sysctl.clone();
         let devices = self.devices.clone();
         let dev_symlinks = self.dev_symlinks.clone();
+        let ldconfig_folders = self.ldconfig_folders.clone();
         let ambient_cap_numbers = self.ambient_cap_numbers.clone();
         let oom_score_adj = self.oom_score_adj;
         let additional_gids = self.additional_gids.clone();
@@ -6049,6 +6067,38 @@ impl Command {
                     }
                 }
 
+                // Step 4.74: Refresh the dynamic linker cache for directories named by
+                // the CDI update-ldcache hook (see CdiHook::update_ldcache_folder()).
+                // Libraries dropped in by create-symlinks above are otherwise invisible
+                // to dlopen-based resolution (Triton, PyTorch's inductor backend, etc.)
+                // until /etc/ld.so.cache is regenerated — see #529. Runs the container's
+                // own ldconfig (tried at its common install paths), not the host's.
+                // Best-effort: a missing ldconfig binary is not fatal.
+                for folder in &ldconfig_folders {
+                    if let Ok(folder_c) = CString::new(folder.as_os_str().as_encoded_bytes()) {
+                        for candidate in [
+                            "/sbin/ldconfig",
+                            "/usr/sbin/ldconfig",
+                            "/bin/ldconfig",
+                            "/usr/bin/ldconfig",
+                        ] {
+                            let prog_c = CString::new(candidate).unwrap();
+                            let argv = [prog_c.as_ptr(), folder_c.as_ptr(), ptr::null()];
+                            let pid = libc::fork();
+                            if pid == 0 {
+                                libc::execv(prog_c.as_ptr(), argv.as_ptr());
+                                libc::_exit(127);
+                            } else if pid > 0 {
+                                let mut status: libc::c_int = 0;
+                                libc::waitpid(pid, &mut status, 0);
+                                if libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0 {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // Step 4.8: Mask sensitive paths
                 if !masked_paths.is_empty() {
                     let dev_null = CString::new("/dev/null").unwrap();
@@ -7158,6 +7208,7 @@ impl Command {
         let sysctl = self.sysctl.clone();
         let devices = self.devices.clone();
         let dev_symlinks = self.dev_symlinks.clone();
+        let ldconfig_folders = self.ldconfig_folders.clone();
         let ambient_cap_numbers = self.ambient_cap_numbers.clone();
         let oom_score_adj = self.oom_score_adj;
         let additional_gids = self.additional_gids.clone();
@@ -9121,6 +9172,38 @@ impl Command {
                         CString::new(target.as_os_str().as_encoded_bytes()),
                     ) {
                         libc::symlink(tgt_c.as_ptr(), link_c.as_ptr());
+                    }
+                }
+
+                // Step 4.74: Refresh the dynamic linker cache for directories named by
+                // the CDI update-ldcache hook (see CdiHook::update_ldcache_folder()).
+                // Libraries dropped in by create-symlinks above are otherwise invisible
+                // to dlopen-based resolution (Triton, PyTorch's inductor backend, etc.)
+                // until /etc/ld.so.cache is regenerated — see #529. Runs the container's
+                // own ldconfig (tried at its common install paths), not the host's.
+                // Best-effort: a missing ldconfig binary is not fatal.
+                for folder in &ldconfig_folders {
+                    if let Ok(folder_c) = CString::new(folder.as_os_str().as_encoded_bytes()) {
+                        for candidate in [
+                            "/sbin/ldconfig",
+                            "/usr/sbin/ldconfig",
+                            "/bin/ldconfig",
+                            "/usr/bin/ldconfig",
+                        ] {
+                            let prog_c = CString::new(candidate).unwrap();
+                            let argv = [prog_c.as_ptr(), folder_c.as_ptr(), ptr::null()];
+                            let pid = libc::fork();
+                            if pid == 0 {
+                                libc::execv(prog_c.as_ptr(), argv.as_ptr());
+                                libc::_exit(127);
+                            } else if pid > 0 {
+                                let mut status: libc::c_int = 0;
+                                libc::waitpid(pid, &mut status, 0);
+                                if libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0 {
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2462,6 +2462,110 @@ devices:
         );
     }
 
+    /// test_cli_device_flag_cdi_update_ldcache_hook
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Regression test for #529: the CDI spec's `update-ldcache` createContainer
+    /// hook (which sits alongside `create-symlinks` in the same spec — see
+    /// `test_cli_device_flag_cdi_create_symlinks_hook`) was silently skipped,
+    /// leaving driver libraries invisible to dlopen-based resolution (Triton,
+    /// PyTorch's inductor backend) even though `create-symlinks` had placed
+    /// them correctly on disk. Since the test rootfs may not ship a real
+    /// `ldconfig` (musl/Alpine doesn't use an ld.so.cache), this bind-mounts a
+    /// fake `ldconfig` shell script to `/sbin/ldconfig` that records its
+    /// invocation args to a host-visible marker file, and asserts it was
+    /// invoked with exactly the `--folder` directory named in the hook.
+    ///
+    /// Failure indicates `CdiHook::update_ldcache_folder()` in `cdi.rs` is not
+    /// parsing the `--folder` arg, or `with_ldconfig_folder()` /
+    /// `add_cdi_device()` are not wiring it through to pre_exec.
+    #[test]
+    #[serial(cdi_rootfs)]
+    fn test_cli_device_flag_cdi_update_ldcache_hook() {
+        if !is_root() {
+            eprintln!("Skipping test_cli_device_flag_cdi_update_ldcache_hook: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_cli_device_flag_cdi_update_ldcache_hook: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let cdi_dir = tempfile::tempdir().expect("tempdir");
+        let marker_dir = tempfile::tempdir().expect("tempdir");
+        let fake_ldconfig_dir = tempfile::tempdir().expect("tempdir");
+        let fake_ldconfig_path = fake_ldconfig_dir.path().join("ldconfig");
+        std::fs::write(
+            &fake_ldconfig_path,
+            "#!/bin/sh\necho \"LDCONFIG_CALLED:$1\" >> /marker/output\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_ldconfig_path)
+            .unwrap()
+            .permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_ldconfig_path, perms).unwrap();
+
+        let spec = format!(
+            r#"
+cdiVersion: "0.6.0"
+kind: "test.pelagos.dev/gpu"
+devices:
+  - name: "0"
+    containerEdits:
+      mounts:
+        - hostPath: "{fake_ldconfig}"
+          containerPath: "/sbin/ldconfig"
+          options: ["bind"]
+        - hostPath: "{marker_dir}"
+          containerPath: "/marker"
+          options: ["bind"]
+      hooks:
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - update-ldcache
+            - --folder
+            - /usr/lib/cditest
+"#,
+            fake_ldconfig = fake_ldconfig_path.display(),
+            marker_dir = marker_dir.path().display(),
+        );
+        std::fs::write(cdi_dir.path().join("vendor.yaml"), spec).unwrap();
+
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .env("PELAGOS_CDI_SPEC_DIRS", cdi_dir.path())
+            .args([
+                "run",
+                "--network",
+                "loopback",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--device",
+                "test.pelagos.dev/gpu=0",
+                "/bin/sh",
+                "-c",
+                "true",
+            ])
+            .output()
+            .expect("pelagos run --device <cdi with update-ldcache hook>");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+
+        let marker_contents =
+            std::fs::read_to_string(marker_dir.path().join("output")).unwrap_or_default();
+        assert!(
+            marker_contents.contains("LDCONFIG_CALLED:/usr/lib/cditest"),
+            "fake ldconfig was not invoked with the hook's --folder directory — \
+             update-ldcache hook was not executed natively. marker contents:\n{}\nstderr:\n{}",
+            marker_contents,
+            stderr
+        );
+    }
+
     /// test_bind_mount_into_dev
     ///
     /// Requires: root, rootfs.


### PR DESCRIPTION
## Summary
- `pelagos run --device` executed the CDI spec's `create-symlinks` hook (#518) but silently skipped the `update-ldcache` hook shipped alongside it in the same spec, so driver libraries were correctly placed/symlinked on disk but never registered in `/etc/ld.so.cache` — breaking dlopen-based CUDA resolution (Triton, PyTorch's inductor backend) even though `nvidia-smi` worked.
- Adds `CdiHook::update_ldcache_folder()` (args-shape parsing) and `Command::with_ldconfig_folder()`, which forks+execs the *container's own* `ldconfig` scoped to the named folder in `pre_exec`, inside the container's mount namespace — same native-builtin pattern as `create-symlinks`, no generic host-hook-binary execution.

Fixes #529.

## Test plan
- [x] `cargo test --lib` — 409 passed
- [x] `sudo -E cargo test --test integration_tests cdi` — 5 passed, including new `test_cli_device_flag_cdi_update_ldcache_hook`
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean
- [x] New integration test documented in `docs/INTEGRATION_TESTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)