### PR TITLE
docs(watcher): require hardware-specific fixes to be validated on real hardware before opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,31 @@ This is a hard requirement, not optional cleanup.
 3. Present the plan to the user (from the issue body)
 4. Quietly implement — no step-by-step narration
 5. Create integration tests and run them to success locally
+5.5. **If the fix targets specific hardware — the DGX Spark aarch64 GPU
+   host (`spark-0d93`) or the ipc x86_64 k3s cluster — build and smoke-test
+   directly on that hardware BEFORE opening the PR.** CI validates generic
+   logic on GitHub-hosted runners; it cannot catch host-specific kernel,
+   driver, or overlay-filesystem behavior (the #522/#526/#529 GPU-passthrough
+   fixes all needed real hardware to actually prove correct — CI alone
+   would have missed the #525 iteration-1 bug, which broke the dynamic
+   linker only on a real multi-layer image on real hardware).
+   - **Spark (aarch64):** SSH in, build with `cargo build --release -p
+     pelagos --bin pelagos` directly on the box (rustup + a repo clone are
+     already set up there from prior sessions), and run the real repro
+     against `target/release/pelagos` directly — no need to install it
+     anywhere first. Do NOT wait for the GitHub Actions release pipeline
+     just to get a testable aarch64 binary — that costs ~15-20 min per
+     iteration for something an SSH build does in ~10s.
+   - **ipc cluster (x86_64):** use the in-cluster build infra
+     (`cluster-build.sh` / `docs/k8s-build/`) rather than waiting on CI.
+   - This step applies identically whether a human session or the
+     autonomous watcher (`pelagos-watch-coordinator.service`,
+     `scripts/watch-coordinator.sh`) is running the cycle — an unattended
+     cycle is not an exemption from validating on real hardware before
+     shipping a hardware-specific fix.
+   - The full CI/release pipeline (steps 6-7 below) still happens after —
+     this step is about confirming the fix *works* before investing in the
+     official release, not a replacement for it.
 6. Commit, push, open a PR
 7. **Immediately launch the CI-merge-release workflow in the background:**
    ```

--- a/scripts/watch-coordinator.sh
+++ b/scripts/watch-coordinator.sh
@@ -113,6 +113,14 @@ autonomously, with these adjustments to that macro (per explicit user direction,
   auto-merge without waiting for further human review.
 - If multiple issues are filed, batch them into one release cycle where it
   makes sense (one version bump covering all fixes), same as recent releases.
+- CLAUDE.md's macro step 5.5 (build+smoke-test directly on target hardware
+  before opening the PR, for spark-0d93/aarch64 or the ipc x86_64 cluster
+  issues) applies to you exactly as it does to an interactive session — you
+  are not exempt from it just because this cycle is unattended. SSH access
+  to spark-0d93 and the in-cluster build infra are both already available;
+  use them. Do not treat a green GitHub Actions CI run as sufficient proof
+  a hardware-specific fix actually works — CI runs on generic GitHub-hosted
+  runners and cannot see host-specific kernel/driver/overlay-fs behavior.
 
 Do NOT touch agent-coordinator or pelagos.json yourself — the watcher script
 handles the post-release coordinator-board write deterministically after this


### PR DESCRIPTION
## Summary

Closes #531. The autonomous watcher (`pelagos-watch-coordinator.service`) always followed the full PR → CI → merge → release cycle with no notion of building/validating on target hardware first, even though every recent GPU-passthrough issue (#522, #526, #529) needed real spark-0d93 hardware to actually prove a fix correct — GitHub Actions CI runs on generic runners and cannot see host-specific kernel/driver/overlay-filesystem behavior. #525's first iteration is a concrete example: it passed CI cleanly but broke the dynamic linker on real hardware with a real multi-layer image.

An interactive session already had this pattern established informally (SSH to spark-0d93, `cargo build --release` directly on the box, ~10s vs. ~15-20min for a full CI/release cycle) but the watcher had no equivalent.

## Changes

- **CLAUDE.md**: adds step 5.5 to the "Once more into the breach!" macro, requiring hardware-specific fixes to be built and smoke-tested directly on target hardware (spark-0d93 via SSH, ipc cluster via `cluster-build.sh`) before opening the PR — explicitly stated to apply identically to the watcher's unattended cycles, not just interactive sessions.
- **scripts/watch-coordinator.sh**: adds a reinforcing bullet directly in the watcher's own prompt template, rather than relying solely on the watcher reading and correctly applying the general CLAUDE.md macro.

This does not replace the full CI/release pipeline — it's a step before opening the PR, to confirm a fix actually works before investing in the official release.

No functional code changes — docs + shell script prompt text only, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)