### PR TITLE
fix(watcher): formalize closed signal vocabulary, add visibility status, route writes through the shared lock

### DIFF
--- a/docs/AGENT_COORDINATION.md
+++ b/docs/AGENT_COORDINATION.md
@@ -34,20 +34,39 @@ agents commit/push to it directly).
     "affected_node": null
   },
   "signals_out": {
-    "to_pelagos": "new-cluster-bugs",    // or "cluster-bug-fix-confirmed" or null
-    "new_issue_numbers": [501, 502]      // only meaningful when to_pelagos == "new-cluster-bugs"
+    "to_pelagos": "new-cluster-bugs",    // closed set — see below
+    "new_issue_numbers": [501, 502],     // issue(s) to act on — required for all actionable signals
+    "note": null                          // required context for priority-request; optional elsewhere
   },
   "updated_by": "k3s-agent",
   "updated_at": "2026-08-05T14:28:30Z"
 }
 ```
 
-`signals_out.to_pelagos` values:
-- `"new-cluster-bugs"` — new GitHub issues filed against pelagos, listed in
-  `new_issue_numbers`. Only this value triggers a pelagos-side work cycle.
-- `"cluster-bug-fix-confirmed"` — a prior fix was validated on the cluster.
-  Currently a no-op on the pelagos side (see Non-goals below).
-- `null` — nothing pending.
+`signals_out.to_pelagos` values — **closed set, exactly these five. Do not
+send anything else.**
+
+| Value | Meaning | Triggers a pelagos-side cycle? |
+|---|---|---|
+| `null` | Nothing pending. | No. |
+| `"new-cluster-bugs"` | New GitHub issues filed against pelagos, listed in `new_issue_numbers`. | Yes. |
+| `"retest-failed"` | A previously-released fix did not hold when retested. `new_issue_numbers` should reference the issue(s) to revisit. | Yes — same cycle as `new-cluster-bugs`. |
+| `"priority-request"` | Urgent, out-of-band attention needed regardless of category (e.g. blocking a time-sensitive cluster operation). `note` **must** explain why it's urgent; set `new_issue_numbers` if a specific issue is driving it. | Yes — same cycle, with the urgency context passed through. |
+| `"cluster-bug-fix-confirmed"` | FYI only — a prior fix was validated on the cluster. Use `note` to say what was confirmed. | No — acknowledged and cleared, but no work cycle (see Non-goals below). |
+
+**Why this is a closed set, not "whatever string makes sense at the time":**
+`retest-failed` and `priority-request` were both used informally for weeks
+before being written down here — the watcher's signal check was (and still
+is, structurally) a single exact-string match, so both were silently
+ignored the entire time, indistinguishable in the logs from genuine idle
+state (`watch.log` showed `signal='priority-request' (nothing to do)` next
+to real idle ticks, with no way to tell them apart without reading the
+literal string). If a new kind of signal is genuinely needed, add it to
+this table **and** to `scripts/watch-coordinator.sh`'s handling in the same
+change — never just start sending a new string and assume the other side
+understands it. The watcher now logs anything outside this closed set as a
+loud, distinct warning rather than silently treating it the same as `null`,
+specifically so future drift like this is visible instead of invisible.
 
 ### `pelagos.json` — pelagos-agent writes, k3s-agent reads
 
@@ -62,6 +81,12 @@ agents commit/push to it directly).
     "target_version": "0.65.74",
     "issues_to_validate": [494]
   },
+  "watcher_status": {
+    "active": false,                     // true while a headless cycle is running
+    "issues": [],                        // issues the current/last cycle is working
+    "signal": null,                      // which signal triggered it
+    "started_at": null
+  },
   "updated_by": "pelagos-agent",
   "updated_at": "2026-08-05T13:56:58Z"
 }
@@ -69,6 +94,13 @@ agents commit/push to it directly).
 
 `signals_out.to_k3s == "upgrade-and-test"` tells the k3s-agent a new release
 is ready at `target_version`, fixing `issues_to_validate`.
+
+`watcher_status` exists so "who is working what right now" is a one-glance
+read of the blackboard instead of checking `git log`, a running process, or
+a worktree directory by hand. Written the moment the watcher claims a
+signal (`active: true`), cleared to `active: false` when the cycle finishes
+— it does not distinguish success/failure (that's `release_status` and the
+issue tracker's job), it only answers "is something in flight."
 
 ## How writes happen — `bin/write-state.sh`, mandatory for both sides
 
@@ -138,10 +170,18 @@ Follow-ups below.
   writes a temp file and renames it into place — `close_write` fires on the
   temp path, not the target, so a watch using only `close_write` never
   triggers on git-committed files.
-- On `cluster.json`'s `signals_out.to_pelagos == "new-cluster-bugs"`:
-  1. Claims the issues — clears the signal, commits agent-coordinator
-     immediately (so concurrent filings land in the *next* signal instead of
-     racing). No push — see "no remote" note above.
+- On `cluster.json`'s `signals_out.to_pelagos` matching one of the three
+  actionable values (`new-cluster-bugs`, `retest-failed`,
+  `priority-request` — see the closed set above; `cluster-bug-fix-confirmed`
+  is acknowledged and cleared but does not reach this flow, and anything
+  outside the closed set is logged loudly and left untouched rather than
+  silently ignored):
+  1. Claims the issues — clears the signal via `write-state.sh` (so this
+     goes through the same cross-agent lock as every other blackboard
+     write, not a raw `jq`+`git commit`), and writes `pelagos.json`'s
+     `watcher_status = {active: true, issues, signal, started_at}` in the
+     same step, so an interactive session can see a cycle just started
+     without needing to check for a running process or worktree.
   2. Records the current latest GitHub release tag (`gh release list`), then
      creates an **isolated git worktree** under
      `~/.local/state/pelagos-watch/worktrees/` from a fresh `origin/main`,
@@ -161,6 +201,9 @@ Follow-ups below.
      `createdAt` — the draft is created before the gate finishes), and
      commits agent-coordinator. If nothing appears after 20 minutes, logs
      that no release was detected rather than writing a stale/fake entry.
+     Either way, `watcher_status.active` is set back to `false` at this
+     point — the cycle is "done" (successfully or not) once this step
+     finishes, whether or not a release resulted.
   4. The headless invocation runs with `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`
      — without it, the harness kills any background task the headless agent
      starts (including its own `ci-merge-release` Workflow poll) after a
@@ -235,10 +278,11 @@ k3s-agent finds a bug
   → commit + push agent-coordinator
 
 pelagos-watch-coordinator.service (inotify fires on moved_to)
-  → claims issues, clears to_pelagos, commit + push
+  → claims issues via write-state.sh: clears to_pelagos, sets watcher_status.active = true
   → headless claude -p: implement fix(es), test, PR, auto-merge, release
-  → writes pelagos.json: signals_out.to_k3s = "upgrade-and-test", target_version, issues_to_validate
-  → commit + push agent-coordinator
+  → writes pelagos.json: signals_out.to_k3s = "upgrade-and-test", target_version, issues_to_validate,
+    watcher_status.active = false
+  → commit agent-coordinator
 
 k3s-agent (if a session is watching, or on next startup check)
   → clears to_k3s
@@ -270,7 +314,8 @@ test after editing the script):
 | Symptom | Check |
 |---------|-------|
 | Service not running | `systemctl --user status pelagos-watch-coordinator.service`; if `enabled` but not `active`, check `journalctl --user -u pelagos-watch-coordinator.service` |
-| Signal set but nothing happened | `tail ~/.local/state/pelagos-watch/watch.log` — look for `skip: another cycle already running` (stale lock) or the signal being logged as ignored |
+| Signal set but nothing happened | `tail ~/.local/state/pelagos-watch/watch.log` — look for `skip: another cycle already running` (stale lock) or a `WARNING: signal='...' is not in the closed set` line (protocol drift — the sender used a value outside the five documented above; fix at the sending side, don't just clear the signal by hand) |
+| Can't tell who's working what right now | Read `pelagos.json`'s `watcher_status` field directly — `active: true` plus `issues`/`started_at` means a headless cycle is in flight; no need to check for a running process or worktree by hand |
 | Watcher missed the write entirely | Confirm the write actually used `moved_to` (a `git commit`/rename) not an in-place edit inside the watched dir — `close_write,moved_to` is set as a belt-and-suspenders, but a plain unlink+recreate outside git may not fire either |
 | Stuck lock | `rm ~/.local/state/pelagos-watch/watch.lock` if a prior headless run crashed mid-cycle without releasing it (check the log first to see why it crashed) |
 | Headless `claude -p` cycle failing | Check `~/.local/state/pelagos-watch/watch.log` for its full transcript output; confirm `pelagos/.claude/settings.local.json` still grants the tool access the cycle needs (Bash, Edit, Write, Workflow) |

--- a/scripts/watch-coordinator.sh
+++ b/scripts/watch-coordinator.sh
@@ -33,37 +33,75 @@ run_once() {
   local signal
   signal=$(jq -r '.signals_out.to_pelagos // empty' "$CLUSTER_JSON")
 
-  if [ "$signal" != "new-cluster-bugs" ]; then
-    log "signal='$signal' (nothing to do)"
-    return 0
-  fi
+  # Closed signal vocabulary — see docs/AGENT_COORDINATION.md. Do not add a
+  # case here without adding the value to that doc's table in the same
+  # change: `retest-failed` and `priority-request` were both used informally
+  # for weeks before being formalized, and were silently dropped by this
+  # exact-string check the entire time (indistinguishable in the log from
+  # genuine idle state) — see #535.
+  case "$signal" in
+    new-cluster-bugs | retest-failed | priority-request)
+      ;; # actionable — falls through to the cycle below
+    cluster-bug-fix-confirmed)
+      local note
+      note=$(jq -r '.signals_out.note // "(no note)"' "$CLUSTER_JSON")
+      log "signal='cluster-bug-fix-confirmed' (FYI, no work cycle) note: $note"
+      "$COORD_DIR/bin/write-state.sh" cluster.json '.signals_out.to_pelagos = null' \
+        "chore: pelagos-agent acknowledges cluster-bug-fix-confirmed" >>"$LOG_FILE" 2>&1 \
+        || log "warning: failed to clear cluster-bug-fix-confirmed signal (will retry on next event)"
+      return 0
+      ;;
+    "")
+      log "signal='' (nothing to do)"
+      return 0
+      ;;
+    *)
+      log "WARNING: signal='$signal' is not in the closed set (null, new-cluster-bugs, retest-failed, priority-request, cluster-bug-fix-confirmed — see docs/AGENT_COORDINATION.md). Ignoring but NOT clearing it, so this is visible until fixed at the source rather than silently indistinguishable from idle."
+      return 0
+      ;;
+  esac
 
   local issues
   issues=$(jq -c '.signals_out.new_issue_numbers // []' "$CLUSTER_JSON")
   local issue_count
   issue_count=$(jq 'length' <<<"$issues")
   if [ "$issue_count" -eq 0 ]; then
-    log "signal=new-cluster-bugs but new_issue_numbers is empty, skipping"
+    log "signal=$signal but new_issue_numbers is empty, skipping"
     return 0
   fi
+  local note
+  note=$(jq -r '.signals_out.note // empty' "$CLUSTER_JSON")
 
-  log "picked up new-cluster-bugs: issues=$issues"
+  log "picked up $signal: issues=$issues"
 
-  # Clear the inbound signal immediately so we don't reprocess it, and so
-  # concurrent filings accumulate into the *next* signal instead of being lost.
+  # Clear the inbound signal and record watcher_status (both writes go
+  # through write-state.sh, which flocks agent-coordinator/.blackboard.lock
+  # — the same lock the other agent's writes go through — so this cross-file
+  # claim can't race a concurrent write the way a raw jq+git-commit could.
+  # See docs/AGENT_COORDINATION.md's "How writes happen".
   #
   # agent-coordinator has NO git remote (confirmed: `git remote -v` is empty)
   # — it's a local-only repo both agents share by filesystem path on this
-  # host, not something to push. Commit only. A `git push` here previously
-  # aborted the whole cycle (set -e) after the signal was already cleared,
-  # silently swallowing issue #496 — do not reintroduce it.
-  (
-    cd "$COORD_DIR"
-    jq '.signals_out.to_pelagos = null | .signals_out.new_issue_numbers = []' "$CLUSTER_JSON" >"$CLUSTER_JSON.tmp"
-    mv "$CLUSTER_JSON.tmp" "$CLUSTER_JSON"
-    git add state/cluster.json
-    git commit -m "chore: pelagos-agent claiming issues $issues for autonomous fix cycle"
-  ) >>"$LOG_FILE" 2>&1
+  # host, not something to push. Commit only — write-state.sh already knows
+  # this and doesn't push.
+  local now_claim
+  now_claim=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  # This write is load-bearing: if it fails, `set -e` must abort here, before
+  # any work happens, so the signal stays set and gets retried — matching
+  # the #496 postmortem (never clear a signal and then risk aborting before
+  # the work it represents actually happens).
+  "$COORD_DIR/bin/write-state.sh" cluster.json \
+    '.signals_out.to_pelagos = null | .signals_out.new_issue_numbers = []' \
+    "chore: pelagos-agent claiming issues $issues for autonomous fix cycle" >>"$LOG_FILE" 2>&1
+
+  # This one is visibility-only (watcher_status), not load-bearing — the
+  # signal is already claimed above, so failing here must NOT abort the
+  # cycle via set -e (that would be the #496 pattern: claimed but never
+  # done). Best-effort: log and continue.
+  "$COORD_DIR/bin/write-state.sh" pelagos.json \
+    ".watcher_status = {active: true, issues: $issues, signal: \"$signal\", started_at: \"$now_claim\"}" \
+    "chore: pelagos-agent watcher status: active on issues $issues (signal=$signal)" >>"$LOG_FILE" 2>&1 \
+    || log "warning: failed to write watcher_status active=true (non-fatal, continuing cycle for issues=$issues)"
 
   # Record the current latest release BEFORE the cycle runs, so we can
   # deterministically detect whether a new one landed afterward — see the
@@ -87,12 +125,35 @@ run_once() {
   git -C "$PELAGOS_REPO" worktree add "$worktree_dir" origin/main --detach >>"$LOG_FILE" 2>&1
   log "created worktree $worktree_dir for issues=$issues"
 
+  local signal_context=""
+  case "$signal" in
+    retest-failed)
+      signal_context="This is a RETEST-FAILED signal: a previously-released fix for these
+issue(s) did not hold when the k3s-agent retested it. Re-investigate from
+scratch — don't assume the earlier fix's diagnosis was correct.
+
+"
+      ;;
+    priority-request)
+      signal_context="This is a PRIORITY-REQUEST signal — the k3s-agent flagged this as
+urgent, out-of-band attention needed (e.g. blocking a time-sensitive
+cluster operation). Treat it as higher priority than a routine cycle.
+
+"
+      ;;
+  esac
+  if [ -n "$note" ]; then
+    signal_context="${signal_context}k3s-agent's note: $note
+
+"
+  fi
+
   local prompt
   prompt="Autonomous release cycle triggered by the agent-coordinator blackboard.
 
 The cluster agent (k3s-experiments) filed these GitHub issues against this repo: $issues
 
-You are working in an isolated git worktree at $worktree_dir, checked out from
+${signal_context}You are working in an isolated git worktree at $worktree_dir, checked out from
 origin/main — NOT the primary ~/Projects/pelagos checkout, which may have an
 interactive session using it concurrently. Do all git operations (branch,
 commit, push) from within $worktree_dir. Pushing branches/tags to origin and
@@ -179,29 +240,37 @@ remains the k3s agent's job."
     fi
   done
 
+  # Both branches below clear watcher_status.active regardless of whether a
+  # release resulted — "active" means "a cycle is in flight", not "a cycle
+  # succeeded"; success/failure lives in release_status and the issue
+  # tracker, not here. Values interpolated into the jq filter (version,
+  # published_at, now, issues) are all machine-generated (git tag, GitHub
+  # API ISO8601 timestamp, jq -c array) rather than free-form text, so this
+  # follows the same low-risk interpolation pattern already used for the
+  # claim-step write above rather than raw jq --arg (write-state.sh's
+  # interface is a single filter string, no --arg passthrough).
   if [ -n "$release_after" ]; then
     local version="${release_after#v}"
     local published_at
     published_at=$(gh release view "$release_after" --repo "$PELAGOS_REMOTE" --json publishedAt --jq '.publishedAt' 2>>"$LOG_FILE")
-    local now
-    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    (
-      cd "$COORD_DIR"
-      jq --arg v "$version" --arg ts "$published_at" --arg now "$now" --argjson issues "$issues" \
-        '.latest_release = $v
-         | .release_status = "released"
-         | .release_timestamp = $ts
-         | .signals_out.to_k3s = "upgrade-and-test"
-         | .signals_out.target_version = $v
-         | .signals_out.issues_to_validate = $issues
-         | .updated_by = "pelagos-agent"
-         | .updated_at = $now' "$PELAGOS_JSON" >"$PELAGOS_JSON.tmp"
-      mv "$PELAGOS_JSON.tmp" "$PELAGOS_JSON"
-      git add state/pelagos.json
-      git commit -m "chore: pelagos-agent post-release state update $release_after (issues $issues)"
-    ) >>"$LOG_FILE" 2>&1
-    log "deterministically wrote coordinator board for $release_after (issues=$issues)"
+    if "$COORD_DIR/bin/write-state.sh" pelagos.json \
+      ".latest_release = \"$version\"
+       | .release_status = \"released\"
+       | .release_timestamp = \"$published_at\"
+       | .signals_out.to_k3s = \"upgrade-and-test\"
+       | .signals_out.target_version = \"$version\"
+       | .signals_out.issues_to_validate = $issues
+       | .watcher_status.active = false" \
+      "chore: pelagos-agent post-release state update $release_after (issues $issues)" >>"$LOG_FILE" 2>&1
+    then
+      log "deterministically wrote coordinator board for $release_after (issues=$issues)"
+    else
+      log "warning: failed to write post-release coordinator board for $release_after (issues=$issues) — the release itself already succeeded, only this board write failed; recover manually per docs/AGENT_COORDINATION.md"
+    fi
   else
+    "$COORD_DIR/bin/write-state.sh" pelagos.json '.watcher_status.active = false' \
+      "chore: pelagos-agent watcher status: cycle finished, no release detected (issues $issues)" >>"$LOG_FILE" 2>&1 \
+      || log "warning: failed to clear watcher_status.active for issues=$issues (non-fatal)"
     log "no new release detected after 20min of polling for issues=$issues — NOT writing coordinator board (check watch.log for the cycle's own output; CI may have failed or nothing shippable was found)"
   fi
 }


### PR DESCRIPTION
Closes #535.

## Problem

The watcher only reacted to the exact string `"new-cluster-bugs"`. `watch.log` history showed the k3s-agent side had been sending `"retest-failed"` (5x) and `"priority-request"` (4x) informally for weeks — both silently dropped by this exact-string check the entire time, logged identically to genuine idle state with no way to distinguish real protocol drift from nothing-to-do. Separately, the watcher's own blackboard writes bypassed `write-state.sh`'s cross-agent lock entirely (raw `jq` + `git commit`), and there was no way to tell "who is working what right now" without checking `git log`, a running process, or a worktree by hand.

## Changes

- **docs/AGENT_COORDINATION.md**: formalizes a closed set of five signal values (`null`, `new-cluster-bugs`, `retest-failed`, `priority-request`, `cluster-bug-fix-confirmed`) — all three non-null actionable values now trigger the same autonomous cycle. States explicitly that future signal values must be added to this doc and the watcher's handling in the same change.
- **scripts/watch-coordinator.sh**: recognizes all five values; anything outside the set is logged as a loud, distinct `WARNING` (not silently treated like idle) and left uncleared so it stays visible until fixed at the source; passes signal-specific context into the headless cycle's prompt.
- Adds `pelagos.json.watcher_status` (active/issues/signal/started_at), written the moment a cycle is claimed and cleared when it finishes.
- Routes the watcher's own blackboard writes through `write-state.sh` instead of raw `jq`+`git commit`, closing the lock-bypass gap.
- Visibility writes are explicitly non-fatal on failure (`set -e` must not abort a claimed cycle over a status-write hiccup — that's the exact #496 failure pattern) — only the load-bearing signal-clear write can abort the cycle.

## Test plan

- [x] `bash -n` syntax check
- [x] Standalone dispatch-logic test against fixture data for all 6 signal cases (3 actionable, `cluster-bug-fix-confirmed`, empty, unrecognized) — all produce the correct branch
- [x] Both interpolated jq filters rendered directly through `jq` to confirm valid, correctly-shaped output JSON
- [ ] No unit/integration tests — this is a shell script + docs, not part of the Rust build; no CI job exercises it directly. Real validation is the next live signal the watcher actually processes.

Note: k3s-experiments' copy of `docs/AGENT_COORDINATION.md` (documented to be kept identical) will be synced separately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)