### PR TITLE
fix(watcher): stop silently abandoning cycles that background a wait

### DIFF
--- a/docs/AGENT_COORDINATION.md
+++ b/docs/AGENT_COORDINATION.md
@@ -85,7 +85,10 @@ specifically so future drift like this is visible instead of invisible.
     "active": false,                     // true while a headless cycle is running
     "issues": [],                        // issues the current/last cycle is working
     "signal": null,                      // which signal triggered it
-    "started_at": null
+    "started_at": null,
+    "last_cycle_outcome": "shipped",     // "shipped" | "no_fix_shipped", written when the cycle ends
+    "last_cycle_issues": [494],          // issues the last-finished cycle covered
+    "last_cycle_finished_at": "2026-08-05T04:54:24Z"
   },
   "updated_by": "pelagos-agent",
   "updated_at": "2026-08-05T13:56:58Z"
@@ -98,9 +101,18 @@ is ready at `target_version`, fixing `issues_to_validate`.
 `watcher_status` exists so "who is working what right now" is a one-glance
 read of the blackboard instead of checking `git log`, a running process, or
 a worktree directory by hand. Written the moment the watcher claims a
-signal (`active: true`), cleared to `active: false` when the cycle finishes
-— it does not distinguish success/failure (that's `release_status` and the
-issue tracker's job), it only answers "is something in flight."
+signal (`active: true`), cleared to `active: false` when the cycle finishes.
+`last_cycle_outcome` answers a narrower, harder question: did the cycle that
+just finished actually ship a fix, or did it end without one? This exists
+because a headless `claude -p` cycle can silently produce nothing — issue
+#537: a cycle backgrounded a test run and ended its turn saying "I'll wait
+for the notification," but a single-shot invocation has no way to be resumed
+after that, so it just exited with no branch/PR while the blackboard already
+showed the issues as claimed. `last_cycle_outcome` is written deterministically
+by the script itself (same principle as the release-tag recheck below), not
+self-reported by the headless agent, so a silently-abandoned cycle is visible
+on the board instead of indistinguishable from one still in progress or one
+that succeeded.
 
 ## How writes happen — `bin/write-state.sh`, mandatory for both sides
 
@@ -322,6 +334,7 @@ test after editing the script):
 | k3s side never picks up `to_k3s` | No persistent watcher exists on that side yet (see Follow-ups) — manually run `/watch-pelagos-release` in a k3s-experiments session, or start a new session (it checks on startup per that repo's CLAUDE.md) |
 | Coordinator board not updated despite a release shipping | Check `watch.log` for `"no new release detected after 20min of polling"` — the write is a deterministic, script-owned 20-minute retry loop against `gh release list`/`gh release view`, not delegated to the headless agent's self-report. If this fires despite a real release existing, either the release took longer than 20 minutes (rare — the gate is normally ~15min) or something's wrong with the retry loop itself; recover manually the same way as any other coordinator-write gap (write `pelagos.json` by hand using `gh release view <tag> --json publishedAt`). |
 | Stale worktree left behind | `git -C ~/Projects/pelagos worktree list` — a crashed cycle can leave one under `~/.local/state/pelagos-watch/worktrees/`; remove with `git -C ~/Projects/pelagos worktree remove <path> --force` |
+| Issue claimed but no branch/PR ever appeared | Read `pelagos.json`'s `watcher_status.last_cycle_outcome` — `"no_fix_shipped"` means the cycle ended without a release, most likely because the headless turn backgrounded a wait and was never resumed (issue #537). Check `watch.log` for the cycle's actual final text to confirm, then manually re-drive the issue (re-run `scripts/watch-coordinator.sh run_once` after re-raising the signal, or work it directly) — the watcher does not auto-retry a dropped cycle. |
 
 ## Explicit non-goals / scope boundaries
 

--- a/scripts/watch-coordinator.sh
+++ b/scripts/watch-coordinator.sh
@@ -190,7 +190,18 @@ reliably happen, so it's no longer this agent's responsibility).
 
 Do not touch cluster.json beyond what was already cleared. Do not act on
 cluster state beyond filing/releasing (no kubectl, no cluster SSH) — that
-remains the k3s agent's job."
+remains the k3s agent's job.
+
+CRITICAL: this is a single-shot invocation with no way to be resumed after
+your turn ends. If you background a test/build/verification command (or start
+a Workflow/Monitor and expect a completion notification) and then end your
+turn saying something like \"I'll wait for it to finish\", THIS PROCESS EXITS
+RIGHT THERE — there is no notification delivery outside an interactive
+session, and no branch/PR will exist for the issue even though the blackboard
+already shows it as claimed. Run every test/build/verification step
+synchronously in the foreground within this same turn (or poll it to
+completion yourself before ending your turn) — never end your turn waiting on
+an async notification you cannot receive."
 
   log "invoking headless claude for issues=$issues"
   (
@@ -260,7 +271,10 @@ remains the k3s agent's job."
        | .signals_out.to_k3s = \"upgrade-and-test\"
        | .signals_out.target_version = \"$version\"
        | .signals_out.issues_to_validate = $issues
-       | .watcher_status.active = false" \
+       | .watcher_status.active = false
+       | .watcher_status.last_cycle_outcome = \"shipped\"
+       | .watcher_status.last_cycle_issues = $issues
+       | .watcher_status.last_cycle_finished_at = \"$published_at\"" \
       "chore: pelagos-agent post-release state update $release_after (issues $issues)" >>"$LOG_FILE" 2>&1
     then
       log "deterministically wrote coordinator board for $release_after (issues=$issues)"
@@ -268,9 +282,20 @@ remains the k3s agent's job."
       log "warning: failed to write post-release coordinator board for $release_after (issues=$issues) — the release itself already succeeded, only this board write failed; recover manually per docs/AGENT_COORDINATION.md"
     fi
   else
-    "$COORD_DIR/bin/write-state.sh" pelagos.json '.watcher_status.active = false' \
+    # Visible on the board, not just in the local watch.log — a cycle that
+    # claims issues and then produces nothing shippable must be as visible
+    # as one that succeeds, or it silently reads as "handled" from the
+    # blackboard's point of view (issue #537: this happened when a headless
+    # turn backgrounded a wait and was never resumed).
+    local now_finished
+    now_finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    "$COORD_DIR/bin/write-state.sh" pelagos.json \
+      ".watcher_status.active = false
+       | .watcher_status.last_cycle_outcome = \"no_fix_shipped\"
+       | .watcher_status.last_cycle_issues = $issues
+       | .watcher_status.last_cycle_finished_at = \"$now_finished\"" \
       "chore: pelagos-agent watcher status: cycle finished, no release detected (issues $issues)" >>"$LOG_FILE" 2>&1 \
-      || log "warning: failed to clear watcher_status.active for issues=$issues (non-fatal)"
+      || log "warning: failed to write watcher_status for no-release outcome, issues=$issues (non-fatal)"
     log "no new release detected after 20min of polling for issues=$issues — NOT writing coordinator board (check watch.log for the cycle's own output; CI may have failed or nothing shippable was found)"
   fi
 }


### PR DESCRIPTION
## Summary
- The #533/#534 headless cycle backgrounded a test run and ended its turn expecting a completion notification that never arrives for a single-shot `claude -p` invocation — it exited with no branch/PR while the blackboard already showed the issues claimed.
- Adds an explicit anti-backgrounding instruction to the headless prompt.
- Adds `watcher_status.last_cycle_outcome` (`"shipped"` / `"no_fix_shipped"`), written deterministically by the script (not the headless agent's self-report), so a dropped cycle is visible on the blackboard instead of silently reading as "handled".
- Docs updated in `docs/AGENT_COORDINATION.md` (schema example, `watcher_status` explanation, new debugging-table row).

Fixes #537

## Test plan
- [x] `bash -n scripts/watch-coordinator.sh` — syntax check passes
- [x] Reviewed jq filters for both the success and no-release write paths
- This is watcher/coordination tooling, not a pelagos runtime feature — no cargo integration test applies (consistent with #536's precedent for the same class of change)