### PR TITLE
fix(image): resolve nested OCI indices, detect corrupted cache on reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.89"
+version = "0.65.90"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5867,6 +5867,41 @@ reference must preserve the image repository (`library/pelagos-mock-multi`) when
 the child manifest's digest, not mangle it into `library/sha256` (which would cause a 404
 on every multi-arch mirror pull).
 
+## `images::test_image_pull_mock_registry_nested_index`
+**Requires root** (writes to `/var/lib/pelagos/`). Same hermetic mock registry pattern, but
+the top-level index's per-platform entry is itself another index (two levels of nesting)
+rather than a direct manifest — the shape buildx commonly produces (real manifest +
+attestation grouped under one per-platform sub-index) and the exact repro from #533
+(`ghcr.io/goauthentik/server:2026.8.0`). Verifies `pelagos image pull` recurses through
+nested indices until it finds a direct manifest. **Why it matters:** before the fix, any
+index-of-indices failed outright with "nested image index not supported", permanently
+blocking pulls of any image published this way regardless of registry or mirror.
+
+## `images::test_concurrent_extract_layer_same_digest_no_corruption`
+**Requires root** (writes to `/var/lib/pelagos/layers/`). Spawns 4 threads calling
+`extract_layer` concurrently for the *same* digest, then asserts the layer exists and
+`layer_verify_integrity()` passes. **Why it matters:** `extract_layer` used to extract into
+a fixed `dest.with_extension("partial")` path shared by every caller for the same digest —
+two concurrent extractions of the same layer (plausible under CRI, where multiple
+pods/containers can trigger a pull around the same time) could delete each other's
+in-progress work or race on the final rename, producing ENOENT or a torn layer directory
+that still ends up with a valid-looking completion marker. This is the most likely root
+cause of #534's "sentinel present, contents corrupt" symptom. Fails if the shared-partial-path
+regression is reintroduced.
+
+## `images::test_layer_corruption_after_extraction_detected_on_reuse`
+**Requires root** (writes to `/var/lib/pelagos/layers/`). Extracts a layer, then deletes one
+extracted file *without* touching the `.pelagos_complete` sentinel — simulating #534's actual
+symptom, where the sentinel survives corruption that happens after extraction completes.
+Asserts: `layer_exists()` still returns `true` (the sentinel alone can't see this — expected,
+not a bug), `layer_verify_integrity()` returns `false` (the recorded entry count no longer
+matches), `discard_layer()` removes the corrupt directory, and a subsequent `extract_layer()`
+succeeds and passes integrity again. **Why it matters:** this is the exact gap #534 reported —
+`pelagos image pull` on an already-corrupted-but-marked-complete image reported "Already
+present" and exited 0 without fixing anything, so the standard "just re-pull to recover"
+instinct silently no-opped and only `image rm` + re-pull actually worked. This test fails if
+the entry-count integrity check regresses or its wiring into the pull fast path is removed.
+
 ## `image_layer_atomicity::test_save_blob_atomic_partial_then_rename`
 **Requires root** (writes to `/var/lib/pelagos/blobs/`). Calls `save_blob` with synthetic
 data for a test digest, then asserts that the final blob file exists, is intact, and no

--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -377,8 +377,34 @@ async fn pull_image(
         if let Ok(existing) = load_image(canonical) {
             let all_cached = existing.layers.iter().all(|d| layer_exists(d));
             if all_cached {
-                println!("Already present: {}", canonical);
-                return Ok(());
+                // layer_exists() only proves each layer's sentinel is present, not
+                // that the directory still matches what was extracted — a layer can
+                // become corrupted after extraction while the sentinel survives
+                // (#534: this made "Already present" silently reuse a broken cache
+                // with no way to recover short of a manual `image rm`). Cheaply
+                // re-verify each layer's recorded entry count before trusting the
+                // cache; discard and fall through to a real re-pull for any layer
+                // that fails, so `pelagos image pull` alone is a reliable recovery
+                // path again.
+                let mut all_valid = true;
+                for d in &existing.layers {
+                    if !image::layer_verify_integrity(d) {
+                        log::warn!(
+                            "layer {} failed integrity check on reuse; discarding for re-extraction",
+                            d.get(..19).unwrap_or(d)
+                        );
+                        let _ = image::discard_layer(d);
+                        all_valid = false;
+                    }
+                }
+                if all_valid {
+                    println!("Already present: {}", canonical);
+                    return Ok(());
+                }
+                println!(
+                    "Detected corrupted cached layer(s) for {}; re-pulling...",
+                    canonical
+                );
             }
         }
     }
@@ -436,23 +462,48 @@ async fn pull_image(
     // The child reference is built with clone_with_digest on oci_ref so the
     // mirror host + repository (`library/alpine`, not `library/sha256`) are
     // preserved in every subsequent request. (#407)
+    //
+    // An index's per-platform entry MAY itself be another index rather than a
+    // direct manifest (valid per the OCI image-spec; buildx commonly wraps the
+    // real per-platform manifest alongside a provenance/attestation manifest
+    // this way — #533). Recurse until a direct manifest is found, matching
+    // containerd/Docker behavior, with a depth cap as a guard against a
+    // pathological or malicious registry looping indices forever.
+    const MAX_INDEX_DEPTH: u32 = 8;
     let (manifest, resolved_ref, digest) = match top_manifest {
         OciManifest::Image(m) => (m, oci_ref.clone(), top_digest),
         OciManifest::ImageIndex(idx) => {
-            let platform_digest = current_platform_resolver(&idx.manifests)
-                .ok_or("image index contains no manifest for the current platform")?;
-            let child_ref = oci_ref.clone_with_digest(platform_digest.clone());
-            log::debug!(
-                "pull: multi-arch index resolved to platform digest {}",
-                platform_digest
-            );
-            let (child_manifest, child_digest) = client
-                .pull_manifest(&child_ref, &auth)
-                .await
-                .map_err(|e| format!("failed to pull platform manifest: {}", e))?;
-            match child_manifest {
-                OciManifest::Image(m) => (m, child_ref, child_digest),
-                OciManifest::ImageIndex(_) => return Err("nested image index not supported".into()),
+            let mut current_idx = idx;
+            let mut current_ref = oci_ref.clone();
+            let mut depth = 0u32;
+            loop {
+                let platform_digest = current_platform_resolver(&current_idx.manifests)
+                    .ok_or("image index contains no manifest for the current platform")?;
+                let child_ref = current_ref.clone_with_digest(platform_digest.clone());
+                log::debug!(
+                    "pull: image index (depth {}) resolved to platform digest {}",
+                    depth,
+                    platform_digest
+                );
+                let (child_manifest, child_digest) = client
+                    .pull_manifest(&child_ref, &auth)
+                    .await
+                    .map_err(|e| format!("failed to pull platform manifest: {}", e))?;
+                match child_manifest {
+                    OciManifest::Image(m) => break (m, child_ref, child_digest),
+                    OciManifest::ImageIndex(nested) => {
+                        depth += 1;
+                        if depth >= MAX_INDEX_DEPTH {
+                            return Err(format!(
+                                "image index nesting exceeds {} levels; giving up",
+                                MAX_INDEX_DEPTH
+                            )
+                            .into());
+                        }
+                        current_idx = nested;
+                        current_ref = child_ref;
+                    }
+                }
             }
         }
     };

--- a/src/image.rs
+++ b/src/image.rs
@@ -263,6 +263,82 @@ pub fn layer_exists(digest: &str) -> bool {
     dir.is_dir() && dir.join(LAYER_COMPLETE_MARKER).exists()
 }
 
+/// Recursively count filesystem entries (files, dirs, symlinks, devices) under
+/// `dir`, not counting `dir` itself. Used to record an extracted layer's entry
+/// count at extraction time and cheaply re-check it later without re-reading
+/// file contents.
+///
+/// Always excludes `LAYER_COMPLETE_MARKER` at the top level: extraction
+/// records the count before the sentinel is written (so it's naturally
+/// excluded there), but a later re-check walks a directory where the
+/// sentinel already exists — excluding it here keeps both counts comparable
+/// regardless of which side of sentinel-creation they're taken from.
+fn count_entries(dir: &Path) -> io::Result<u64> {
+    count_entries_inner(dir, true)
+}
+
+fn count_entries_inner(dir: &Path, is_top_level: bool) -> io::Result<u64> {
+    let mut count = 0u64;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if is_top_level && entry.file_name() == std::ffi::OsStr::new(LAYER_COMPLETE_MARKER) {
+            continue;
+        }
+        count += 1;
+        // symlink_metadata so a symlink to a directory is counted as a leaf,
+        // not recursed into (matches tar semantics: a symlink entry is one item).
+        let meta = entry.metadata()?;
+        if meta.is_dir() {
+            count += count_entries_inner(&entry.path(), false)?;
+        }
+    }
+    Ok(count)
+}
+
+/// Cheaply re-check a layer that already passed `layer_exists()` for signs of
+/// post-extraction corruption (e.g. files disappearing from a shared
+/// content-addressable layer directory after extraction completed).
+///
+/// `layer_exists()` only proves the sentinel was written; it does not prove the
+/// directory still matches what was written. This walks the directory and
+/// compares its current entry count against the count recorded in the sentinel
+/// at extraction time. Layers extracted before this check existed have an empty
+/// sentinel (no recorded count) and are trusted as-is — this is a best-effort
+/// check for future corruption, not a retroactive audit of the existing store.
+///
+/// Returns `false` only when a count was recorded AND it no longer matches;
+/// returns `true` for a missing layer, a missing/empty sentinel, or an I/O
+/// error walking the directory (fail open — an unreadable directory is a
+/// separate problem this check should not mask as "corrupt").
+pub fn layer_verify_integrity(digest: &str) -> bool {
+    let dir = layer_dir(digest);
+    let marker = dir.join(LAYER_COMPLETE_MARKER);
+    let recorded = match std::fs::read_to_string(&marker) {
+        Ok(s) if !s.trim().is_empty() => s,
+        _ => return true,
+    };
+    let expected: u64 = match recorded.trim().parse() {
+        Ok(n) => n,
+        Err(_) => return true,
+    };
+    match count_entries(&dir) {
+        Ok(actual) => actual == expected,
+        Err(_) => true,
+    }
+}
+
+/// Remove a layer directory so the next pull re-downloads and re-extracts it.
+/// Used to discard a layer that `layer_verify_integrity()` found corrupted.
+pub fn discard_layer(digest: &str) -> io::Result<()> {
+    let dir = layer_dir(digest);
+    if dir.is_dir() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    let rootless_marker = dir.with_extension("rootless");
+    let _ = std::fs::remove_file(&rootless_marker);
+    Ok(())
+}
+
 /// Return the raw blob path for the given digest.
 pub fn blob_path(digest: &str) -> std::path::PathBuf {
     crate::paths::blob_path(digest)
@@ -403,12 +479,24 @@ pub fn extract_layer(digest: &str, tar_path: &Path, media_type: &str) -> io::Res
         }
     }
 
-    // Extract to a temporary sibling, then rename atomically.
-    let partial = dest.with_extension("partial");
-    if partial.exists() {
-        std::fs::remove_dir_all(&partial)?;
-    }
-    std::fs::create_dir_all(&partial)?;
+    // Extract to a uniquely-named temporary sibling, then rename atomically.
+    //
+    // MUST be unique per call, not a fixed `dest.with_extension("partial")` —
+    // two concurrent extract_layer() calls for the same digest (e.g. the same
+    // image pulled by multiple containers/pods around the same time) used to
+    // share one fixed partial path, so one caller's `remove_dir_all` could
+    // delete the directory the other was mid-write into, producing ENOENT and,
+    // worse, a silently torn extraction if the deletion raced with the
+    // rename instead of the write loop (#534's most likely root cause — a
+    // layer whose sentinel says "complete" but whose contents don't match).
+    std::fs::create_dir_all(dest.parent().unwrap())?;
+    // Detach from TempDir's auto-cleanup-on-drop: on the happy path this
+    // directory is renamed into `dest` before this function returns, and on
+    // the lost-the-race path below it's removed explicitly.
+    let partial = tempfile::Builder::new()
+        .prefix(".partial-")
+        .tempdir_in(dest.parent().unwrap())?
+        .keep();
 
     let file = std::fs::File::open(tar_path)?;
 
@@ -492,16 +580,31 @@ pub fn extract_layer(digest: &str, tar_path: &Path, media_type: &str) -> io::Res
         }
     }
 
-    // Ensure parent dir exists and rename partial → final.
-    std::fs::create_dir_all(dest.parent().unwrap())?;
-    std::fs::rename(&partial, &dest)?;
+    // Rename partial → final. If a concurrent extract_layer() for the same
+    // digest already won this race, dest now exists (non-empty) and this
+    // rename fails (Linux `rename(2)` onto a non-empty directory) — that's
+    // not our error to report, the layer is already there. Only treat it as
+    // a real failure if dest doesn't already have a valid completion marker.
+    if let Err(e) = std::fs::rename(&partial, &dest) {
+        let _ = std::fs::remove_dir_all(&partial);
+        if dest.join(LAYER_COMPLETE_MARKER).exists() {
+            return Ok(dest);
+        }
+        return Err(e);
+    }
 
     // Write the completion sentinel and fsync it so that it survives a power
     // cut. Without this, the directory rename can be journaled while the file
     // data (and the sentinel itself) are still in the page cache — leaving a
-    // directory that looks valid but is empty or corrupt.
+    // directory that looks valid but is empty or corrupt. The sentinel's
+    // content is the extracted entry count, so a later reuse of this "already
+    // present" layer can cheaply detect post-extraction corruption via
+    // layer_verify_integrity() (#534) rather than trusting presence alone.
     {
-        let f = std::fs::File::create(dest.join(LAYER_COMPLETE_MARKER))?;
+        use std::io::Write as _;
+        let entry_count = count_entries(&dest).unwrap_or(0);
+        let mut f = std::fs::File::create(dest.join(LAYER_COMPLETE_MARKER))?;
+        write!(f, "{}", entry_count)?;
         f.sync_all()?;
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8946,6 +8946,34 @@ mod images {
             MockOciRegistry { port, shutdown }
         }
 
+        /// Spawn a registry whose top-level index's per-platform entry is
+        /// itself another index (not a direct manifest) — the shape buildx
+        /// commonly produces (real manifest + attestation, both listed under
+        /// one per-platform sub-index). Regression coverage for #533.
+        fn spawn_nested(image_name: &str) -> Self {
+            let routes = build_routes_nested(image_name);
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock registry");
+            let port = listener.local_addr().unwrap().port();
+            listener.set_nonblocking(true).unwrap();
+
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown2 = Arc::clone(&shutdown);
+
+            std::thread::spawn(move || {
+                while !shutdown2.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => serve_request(stream, &routes),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(std::time::Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            MockOciRegistry { port, shutdown }
+        }
+
         fn endpoint(&self) -> String {
             format!("http://127.0.0.1:{}", self.port)
         }
@@ -9058,6 +9086,115 @@ mod images {
         );
 
         // Layer blob.
+        r.insert(
+            format!("/v2/{}/blobs/{}", image_name, layer_digest),
+            (
+                "application/vnd.oci.image.layer.v1.tar+gzip".to_string(),
+                layer_digest,
+                layer_bytes,
+            ),
+        );
+
+        r
+    }
+
+    /// Two-level index: top-level index -> per-platform index -> real manifest.
+    /// Mirrors #533's actual repro shape (ghcr.io/goauthentik/server:2026.8.0).
+    fn build_routes_nested(image_name: &str) -> Routes {
+        use flate2::{write::GzEncoder, Compression};
+        use tar::Builder;
+
+        let mut tar_raw: Vec<u8> = Vec::new();
+        {
+            let mut b = Builder::new(&mut tar_raw);
+            b.finish().unwrap();
+        }
+        let diff_id = sha256_of(&tar_raw);
+
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(&tar_raw).unwrap();
+        let layer_bytes = gz.finish().unwrap();
+        let layer_digest = sha256_of(&layer_bytes);
+
+        let config_json = format!(
+            r#"{{"architecture":"amd64","os":"linux","rootfs":{{"type":"layers","diff_ids":["{}"]}},"config":{{}}}}"#,
+            diff_id
+        );
+        let config_bytes = config_json.into_bytes();
+        let config_digest = sha256_of(&config_bytes);
+
+        let manifest_json = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{{"mediaType":"application/vnd.oci.image.config.v1+json","size":{},"digest":"{}"}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","size":{},"digest":"{}"}}]}}"#,
+            config_bytes.len(),
+            config_digest,
+            layer_bytes.len(),
+            layer_digest
+        );
+        let manifest_bytes = manifest_json.into_bytes();
+        let manifest_digest = sha256_of(&manifest_bytes);
+
+        // Per-platform sub-index wrapping the real manifest (standing in for
+        // the real-world shape's manifest + attestation pair — one entry is
+        // enough to prove recursion works).
+        let child_index_json = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":{},"digest":"{}","platform":{{"architecture":"amd64","os":"linux"}}}}]}}"#,
+            manifest_bytes.len(),
+            manifest_digest
+        );
+        let child_index_bytes = child_index_json.into_bytes();
+        let child_index_digest = sha256_of(&child_index_bytes);
+
+        // Top-level index: per-platform entry points at the sub-index above,
+        // not directly at a manifest.
+        let top_index_json = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"application/vnd.oci.image.index.v1+json","size":{},"digest":"{}","platform":{{"architecture":"amd64","os":"linux"}}}}]}}"#,
+            child_index_bytes.len(),
+            child_index_digest
+        );
+        let top_index_bytes = top_index_json.into_bytes();
+
+        let mut r: Routes = HashMap::new();
+
+        r.insert(
+            "/v2/".to_string(),
+            (
+                "application/json".to_string(),
+                String::new(),
+                b"{}".to_vec(),
+            ),
+        );
+        r.insert(
+            format!("/v2/{}/manifests/latest", image_name),
+            (
+                "application/vnd.oci.image.index.v1+json".to_string(),
+                sha256_of(&top_index_bytes),
+                top_index_bytes,
+            ),
+        );
+        r.insert(
+            format!("/v2/{}/manifests/{}", image_name, child_index_digest),
+            (
+                "application/vnd.oci.image.index.v1+json".to_string(),
+                child_index_digest,
+                child_index_bytes,
+            ),
+        );
+        r.insert(
+            format!("/v2/{}/manifests/{}", image_name, manifest_digest),
+            (
+                "application/vnd.oci.image.manifest.v1+json".to_string(),
+                manifest_digest,
+                manifest_bytes,
+            ),
+        );
+        r.insert(
+            format!("/v2/{}/blobs/{}", image_name, config_digest),
+            (
+                "application/vnd.oci.image.config.v1+json".to_string(),
+                config_digest,
+                config_bytes,
+            ),
+        );
         r.insert(
             format!("/v2/{}/blobs/{}", image_name, layer_digest),
             (
@@ -10486,6 +10623,240 @@ mod images {
 
         // Cleanup.
         let _ = pelagos::image::remove_image(reference);
+    }
+
+    /// test_image_pull_mock_registry_nested_index
+    ///
+    /// Requires: root (writes to /var/lib/pelagos/).
+    ///
+    /// Pulls an image whose top-level index's per-platform entry is itself
+    /// another index rather than a direct manifest — the shape buildx commonly
+    /// produces and the exact repro from #533
+    /// (ghcr.io/goauthentik/server:2026.8.0). Before the fix this failed with
+    /// "nested image index not supported"; the fix recurses through nested
+    /// indices until a direct manifest is found.
+    ///
+    /// Failure indicates a regression in the nested-index recursion added for #533.
+    #[test]
+    fn test_image_pull_mock_registry_nested_index() {
+        if !is_root() {
+            eprintln!("Skipping test_image_pull_mock_registry_nested_index: requires root");
+            return;
+        }
+
+        let image_name = "library/pelagos-mock-nested";
+        let registry = MockOciRegistry::spawn_nested(image_name);
+
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            format!("[mirrors]\n\"docker.io\" = [\"{}\"]\n", registry.endpoint()),
+        )
+        .expect("write registries.toml");
+
+        let reference = "docker.io/library/pelagos-mock-nested:latest";
+        let _ = pelagos::image::remove_image(reference);
+
+        let result = pull_via_binary(reference, tmp.path());
+        assert!(
+            result.is_ok(),
+            "nested-index pull failed (#533 regression?): {:?}",
+            result.err()
+        );
+
+        let manifest = pelagos::image::load_image(reference)
+            .expect("image manifest not stored after nested-index pull");
+        assert_eq!(
+            manifest.layers.len(),
+            1,
+            "expected 1 layer after nested-index resolution"
+        );
+        assert!(
+            pelagos::image::layer_exists(&manifest.layers[0]),
+            "layer dir missing after nested-index pull"
+        );
+
+        // Cleanup.
+        let _ = pelagos::image::remove_image(reference);
+    }
+
+    /// test_concurrent_extract_layer_same_digest_no_corruption
+    ///
+    /// Requires: root (writes to /var/lib/pelagos/).
+    ///
+    /// Extracts the same layer digest from two threads concurrently and
+    /// asserts the resulting layer directory still has a matching entry count
+    /// per `layer_verify_integrity()` (#534). Guards against the corruption
+    /// class the integrity check was added to catch — a torn write from two
+    /// extractions racing on the same content-addressable digest — even
+    /// though the original cluster incident's exact trigger was never
+    /// reproduced outside the cluster.
+    #[test]
+    #[serial]
+    fn test_concurrent_extract_layer_same_digest_no_corruption() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_concurrent_extract_layer_same_digest_no_corruption: requires root"
+            );
+            return;
+        }
+
+        use pelagos::image;
+
+        let mut tar_raw: Vec<u8> = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut tar_raw);
+            for i in 0..20 {
+                let data = format!("payload-{i}").into_bytes();
+                let mut hdr = tar::Header::new_gnu();
+                hdr.set_size(data.len() as u64);
+                hdr.set_mode(0o644);
+                hdr.set_cksum();
+                b.append_data(&mut hdr, format!("file-{i}.txt"), &data[..])
+                    .unwrap();
+            }
+            b.finish().unwrap();
+        }
+        let gz = {
+            let mut e = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            e.write_all(&tar_raw).unwrap();
+            e.finish().unwrap()
+        };
+
+        let digest = "sha256:test_concurrent_extract_no_corruption_deadbeef";
+        let layer_path = image::layer_dir(digest);
+        let _ = std::fs::remove_dir_all(&layer_path);
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let gz = gz.clone();
+                let digest = digest.to_string();
+                std::thread::spawn(move || {
+                    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+                    tmp.write_all(&gz).unwrap();
+                    tmp.flush().unwrap();
+                    image::extract_layer(
+                        &digest,
+                        tmp.path(),
+                        "application/vnd.oci.image.layer.v1.tar+gzip",
+                    )
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap().expect("concurrent extract_layer");
+        }
+
+        assert!(
+            image::layer_exists(digest),
+            "layer should exist after concurrent extraction"
+        );
+        assert!(
+            image::layer_verify_integrity(digest),
+            "layer entry count should match after concurrent extraction (no torn write)"
+        );
+
+        let _ = std::fs::remove_dir_all(&layer_path);
+    }
+
+    /// test_layer_missing_marker_causes_re_extraction (integrity variant)
+    ///
+    /// Requires: root (writes to /var/lib/pelagos/).
+    ///
+    /// Extracts a real layer, then deletes files from the extracted directory
+    /// WITHOUT touching the completion sentinel — simulating #534's actual
+    /// symptom (a layer whose sentinel survives but whose contents no longer
+    /// match what was recorded, so `pelagos image pull` silently reported
+    /// "Already present" over a broken cache). Asserts:
+    ///   - `layer_exists()` still returns true (sentinel alone can't detect this)
+    ///   - `layer_verify_integrity()` returns false (the entry-count check catches it)
+    ///   - `discard_layer()` removes it so a subsequent extract_layer() succeeds
+    ///
+    /// Failure indicates the #534 corruption-on-reuse fix has regressed.
+    #[test]
+    #[serial]
+    fn test_layer_corruption_after_extraction_detected_on_reuse() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_layer_corruption_after_extraction_detected_on_reuse: requires root"
+            );
+            return;
+        }
+
+        use pelagos::image;
+
+        let mut tar_raw: Vec<u8> = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut tar_raw);
+            for i in 0..5 {
+                let data = format!("payload-{i}").into_bytes();
+                let mut hdr = tar::Header::new_gnu();
+                hdr.set_size(data.len() as u64);
+                hdr.set_mode(0o644);
+                hdr.set_cksum();
+                b.append_data(&mut hdr, format!("file-{i}.txt"), &data[..])
+                    .unwrap();
+            }
+            b.finish().unwrap();
+        }
+        let gz = {
+            let mut e = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            e.write_all(&tar_raw).unwrap();
+            e.finish().unwrap()
+        };
+
+        let digest = "sha256:test_corruption_after_extraction_facefeed";
+        let layer_path = image::layer_dir(digest);
+        let _ = std::fs::remove_dir_all(&layer_path);
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(&gz).unwrap();
+        tmp.flush().unwrap();
+        image::extract_layer(
+            digest,
+            tmp.path(),
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        )
+        .expect("extract_layer");
+
+        assert!(image::layer_exists(digest), "layer should exist");
+        assert!(
+            image::layer_verify_integrity(digest),
+            "freshly extracted layer should pass integrity check"
+        );
+
+        // Simulate post-extraction corruption: delete a file, leave the sentinel.
+        std::fs::remove_file(layer_path.join("file-0.txt")).expect("remove file to corrupt");
+
+        assert!(
+            image::layer_exists(digest),
+            "layer_exists() cannot detect post-extraction corruption (sentinel untouched) — this is expected, not a bug"
+        );
+        assert!(
+            !image::layer_verify_integrity(digest),
+            "layer_verify_integrity() should detect the missing file"
+        );
+
+        image::discard_layer(digest).expect("discard_layer");
+        assert!(
+            !image::layer_exists(digest),
+            "layer should be gone after discard_layer()"
+        );
+
+        // Re-extraction should succeed and pass integrity again.
+        image::extract_layer(
+            digest,
+            tmp.path(),
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+        )
+        .expect("re-extract after discard");
+        assert!(
+            image::layer_verify_integrity(digest),
+            "re-extracted layer should pass integrity"
+        );
+
+        let _ = std::fs::remove_dir_all(&layer_path);
     }
 }
 


### PR DESCRIPTION
## Summary
- **#533**: `pull_image()` recurses through nested OCI image indices (index → index → manifest) until it finds a direct manifest, matching containerd/Docker. Fixes pulls of images like `ghcr.io/goauthentik/server:2026.8.0` that fail today with "nested image index not supported".
- **#534**: the "Already present" pull fast path now re-verifies each layer's recorded entry count (`layer_verify_integrity()`) before trusting the cache, discarding and re-pulling anything that fails — so `pelagos image pull` alone is a reliable recovery path again instead of silently no-opping over a corrupted cache.
- Also fixed the likely actual root cause behind #534: `extract_layer()` used a fixed, digest-keyed `.partial` path shared by every concurrent caller extracting the same layer, which could race (one caller deleting another's in-progress work, or both racing on the final rename) and produce exactly the "sentinel present, contents corrupt" symptom reported. Each extraction now uses a uniquely-named temp directory.

## Test plan
- [x] `cargo test --lib` — 409 passed
- [x] `sudo cargo test --test integration_tests -- images:: image_layer_atomicity:: image_layer_integrity::` — all passing, including the 3 new tests:
  - `test_image_pull_mock_registry_nested_index` — reproduces #533's exact two-level index shape against a hermetic mock registry
  - `test_concurrent_extract_layer_same_digest_no_corruption` — 4 threads racing `extract_layer()` on the same digest; failed reliably (`ENOENT`) before the fix
  - `test_layer_corruption_after_extraction_detected_on_reuse` — simulates post-extraction corruption (sentinel intact, file missing) and verifies detection + recovery
- [x] `cargo fmt --check`, `cargo clippy --lib --bin pelagos -- -D warnings`
- [x] Documented all 3 new tests in `docs/INTEGRATION_TESTS.md`
- Not hardware-specific (generic pull/filesystem logic, no kernel/driver dependency) — CLAUDE.md's target-hardware smoke-test step doesn't apply here.

Fixes #533
Fixes #534