### PR TITLE
fix(image): close two more #534 gaps found by independent cluster validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.90"
+version = "0.65.92"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5877,6 +5877,20 @@ nested indices until it finds a direct manifest. **Why it matters:** before the 
 index-of-indices failed outright with "nested image index not supported", permanently
 blocking pulls of any image published this way regardless of registry or mirror.
 
+## `images::test_pull_self_heals_legacy_marker_layer`
+**Requires root** (writes to `/var/lib/pelagos/`). Reproduces the actual gap the k3s-agent
+found in the first #534 fix attempt (v0.65.92): pulls a real image via a mock registry, then
+truncates its layer's `.pelagos_complete` sentinel to empty (the format every pre-#534 build
+wrote) and deletes a file from the layer directory — simulating a node upgraded from before
+this fix, with pre-existing corruption from the original incident still on disk. Asserts the
+next `pelagos image pull` (without `image rm`) does NOT report "Already present", the sentinel
+carries a real entry count afterward, and `layer_verify_integrity()` passes. **Why it
+matters:** the first #534 fix (v0.65.92) trusted an empty/legacy sentinel as "can't verify,
+assume OK" for backward compatibility, which made the integrity check a complete no-op for
+exactly the layers already corrupted in the field before the check existed — the cluster's
+independent re-run of the SIGKILL-mid-extraction repro on v0.65.92 still failed with "Already
+present" for precisely this reason. Fails if legacy sentinels are ever trusted again.
+
 ## `images::test_concurrent_extract_layer_same_digest_no_corruption`
 **Requires root** (writes to `/var/lib/pelagos/layers/`). Spawns 4 threads calling
 `extract_layer` concurrently for the *same* digest, then asserts the layer exists and

--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -537,17 +537,32 @@ async fn pull_image(
         let is_wasm = pelagos::wasm::is_wasm_media_type(media_type);
 
         if layer_exists(layer_digest) {
-            cached += 1;
-            println!(
-                "  Layer {}/{}: {} (cached{})",
-                i + 1,
-                manifest.layers.len(),
-                &layer_digest[7..19.min(layer_digest.len())],
-                if is_wasm { ", wasm" } else { "" }
+            if image::layer_verify_integrity(layer_digest) {
+                cached += 1;
+                println!(
+                    "  Layer {}/{}: {} (cached{})",
+                    i + 1,
+                    manifest.layers.len(),
+                    &layer_digest[7..19.min(layer_digest.len())],
+                    if is_wasm { ", wasm" } else { "" }
+                );
+                layer_digests.push(layer_digest.clone());
+                layer_types.push(media_type.to_string());
+                continue;
+            }
+            // layer_exists() only proves the sentinel is present; it does not
+            // prove the directory still matches what was extracted (#534: this
+            // per-layer skip is reached on every pull, mutable tag or not,
+            // regardless of whether the whole-image "Already present" fast
+            // path above ever ran). extract_layer() itself also short-circuits
+            // on sentinel presence alone, so it would silently no-op on a
+            // corrupted-but-marked layer too — discard first so the download
+            // path below genuinely re-extracts.
+            log::warn!(
+                "layer {} failed integrity check on reuse; discarding for re-download",
+                layer_digest.get(..19).unwrap_or(layer_digest)
             );
-            layer_digests.push(layer_digest.clone());
-            layer_types.push(media_type.to_string());
-            continue;
+            let _ = image::discard_layer(layer_digest);
         }
 
         println!(

--- a/src/image.rs
+++ b/src/image.rs
@@ -302,24 +302,31 @@ fn count_entries_inner(dir: &Path, is_top_level: bool) -> io::Result<u64> {
 /// `layer_exists()` only proves the sentinel was written; it does not prove the
 /// directory still matches what was written. This walks the directory and
 /// compares its current entry count against the count recorded in the sentinel
-/// at extraction time. Layers extracted before this check existed have an empty
-/// sentinel (no recorded count) and are trusted as-is — this is a best-effort
-/// check for future corruption, not a retroactive audit of the existing store.
+/// at extraction time.
 ///
-/// Returns `false` only when a count was recorded AND it no longer matches;
-/// returns `true` for a missing layer, a missing/empty sentinel, or an I/O
-/// error walking the directory (fail open — an unreadable directory is a
-/// separate problem this check should not mask as "corrupt").
+/// A legacy sentinel (empty — written by any pre-#534 build) or an unparseable
+/// one is treated as a FAILURE, not trusted as-is: an earlier version of this
+/// check trusted empty sentinels for backward compatibility, which made it a
+/// complete no-op for exactly the layers already corrupted in the field before
+/// this check existed — precisely the ones #534 needs caught. Every legacy
+/// layer now gets re-extracted exactly once (self-healing the on-disk cache on
+/// first pull after upgrade); after that its sentinel carries a real count and
+/// this check is fully effective for it.
+///
+/// Returns `false` when a count was recorded and no longer matches, or when
+/// the sentinel is legacy/unparseable. Returns `true` only for a missing layer
+/// or an I/O error walking the directory (fail open — an unreadable directory
+/// is a separate problem this check should not mask as "corrupt").
 pub fn layer_verify_integrity(digest: &str) -> bool {
     let dir = layer_dir(digest);
     let marker = dir.join(LAYER_COMPLETE_MARKER);
     let recorded = match std::fs::read_to_string(&marker) {
-        Ok(s) if !s.trim().is_empty() => s,
-        _ => return true,
+        Ok(s) => s,
+        Err(_) => return true,
     };
     let expected: u64 = match recorded.trim().parse() {
         Ok(n) => n,
-        Err(_) => return true,
+        Err(_) => return false,
     };
     match count_entries(&dir) {
         Ok(actual) => actual == expected,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8979,6 +8979,40 @@ mod images {
         }
     }
 
+    impl MockOciRegistry {
+        /// Spawn a single-arch registry whose layer contains one file with the
+        /// given content, rather than the empty-tar layer every other
+        /// `spawn()`/`spawn_nested()` caller shares. Needed for tests that
+        /// mutate the extracted layer directory on disk (corruption
+        /// simulation): the empty-tar layer's digest — and therefore its
+        /// on-disk content-addressable directory — is identical across every
+        /// test using the shared builder, so mutating it races any other
+        /// test running concurrently against the same digest.
+        fn spawn_with_content(image_name: &str, file_name: &str, content: &[u8]) -> Self {
+            let routes = build_routes_with_content(image_name, file_name, content);
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock registry");
+            let port = listener.local_addr().unwrap().port();
+            listener.set_nonblocking(true).unwrap();
+
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown2 = Arc::clone(&shutdown);
+
+            std::thread::spawn(move || {
+                while !shutdown2.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => serve_request(stream, &routes),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(std::time::Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            MockOciRegistry { port, shutdown }
+        }
+    }
+
     impl Drop for MockOciRegistry {
         fn drop(&mut self) {
             self.shutdown.store(true, Ordering::Relaxed);
@@ -8994,16 +9028,43 @@ mod images {
     }
 
     fn build_routes(image_name: &str, multi_arch: bool) -> Routes {
-        use flate2::{write::GzEncoder, Compression};
-        use tar::Builder;
-
         // Empty tar layer (two 512-byte EOF blocks).
         let mut tar_raw: Vec<u8> = Vec::new();
         {
-            let mut b = Builder::new(&mut tar_raw);
+            let mut b = tar::Builder::new(&mut tar_raw);
             b.finish().unwrap();
         }
         let diff_id = sha256_of(&tar_raw);
+
+        build_routes_from_tar(image_name, multi_arch, tar_raw, diff_id)
+    }
+
+    /// Single-arch registry whose layer tar contains one named file — gives a
+    /// digest (and therefore on-disk layer directory) unique to the content,
+    /// unlike `build_routes`'s always-identical empty-tar layer.
+    fn build_routes_with_content(image_name: &str, file_name: &str, content: &[u8]) -> Routes {
+        let mut tar_raw: Vec<u8> = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut tar_raw);
+            let mut hdr = tar::Header::new_gnu();
+            hdr.set_size(content.len() as u64);
+            hdr.set_mode(0o644);
+            hdr.set_cksum();
+            b.append_data(&mut hdr, file_name, content).unwrap();
+            b.finish().unwrap();
+        }
+        let diff_id = sha256_of(&tar_raw);
+
+        build_routes_from_tar(image_name, false, tar_raw, diff_id)
+    }
+
+    fn build_routes_from_tar(
+        image_name: &str,
+        multi_arch: bool,
+        tar_raw: Vec<u8>,
+        diff_id: String,
+    ) -> Routes {
+        use flate2::{write::GzEncoder, Compression};
 
         let mut gz = GzEncoder::new(Vec::new(), Compression::default());
         gz.write_all(&tar_raw).unwrap();
@@ -10674,6 +10735,110 @@ mod images {
         assert!(
             pelagos::image::layer_exists(&manifest.layers[0]),
             "layer dir missing after nested-index pull"
+        );
+
+        // Cleanup.
+        let _ = pelagos::image::remove_image(reference);
+    }
+
+    /// test_pull_self_heals_legacy_marker_layer
+    ///
+    /// Requires: root (writes to /var/lib/pelagos/).
+    ///
+    /// Reproduces the actual gap the k3s-agent found in the first #534 fix
+    /// attempt (v0.65.92): `layer_verify_integrity()` originally trusted an
+    /// empty sentinel ("legacy format, can't verify, assume OK") for backward
+    /// compatibility — which made the check a complete no-op for exactly the
+    /// layers already corrupted in the field *before* the check existed. A
+    /// cluster's independent re-run of the SIGKILL-mid-extraction repro on
+    /// v0.65.92 still failed with "Already present" because the corrupted
+    /// layer from the original incident had exactly this kind of legacy
+    /// marker, so the new integrity check silently waved it through.
+    ///
+    /// Simulates that exact state directly (extract a real layer via the mock
+    /// registry, then truncate its sentinel to empty to look pre-#534, then
+    /// delete a file from it to actually corrupt it) and asserts that the
+    /// NEXT `pelagos image pull` — via both the whole-image "Already present"
+    /// fast path and the per-layer cache-skip inside the download loop —
+    /// detects it and re-extracts rather than reporting "Already present".
+    ///
+    /// Failure indicates the legacy-marker-trusts-blindly regression is back.
+    #[test]
+    fn test_pull_self_heals_legacy_marker_layer() {
+        if !is_root() {
+            eprintln!("Skipping test_pull_self_heals_legacy_marker_layer: requires root");
+            return;
+        }
+
+        let image_name = "library/pelagos-mock-legacy-marker";
+        let registry = MockOciRegistry::spawn_with_content(
+            image_name,
+            "legacy-marker-victim.txt",
+            b"unique layer content for test_pull_self_heals_legacy_marker_layer",
+        );
+
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            format!("[mirrors]\n\"docker.io\" = [\"{}\"]\n", registry.endpoint()),
+        )
+        .expect("write registries.toml");
+
+        let reference = "docker.io/library/pelagos-mock-legacy-marker:latest";
+        let _ = pelagos::image::remove_image(reference);
+
+        // Real first pull — proper (non-empty, entry-count) marker.
+        pull_via_binary(reference, tmp.path()).expect("initial pull should succeed");
+        let manifest =
+            pelagos::image::load_image(reference).expect("manifest should exist after pull");
+        assert_eq!(manifest.layers.len(), 1);
+        let digest = &manifest.layers[0];
+        let layer_dir = pelagos::image::layer_dir(digest);
+
+        // Downgrade the sentinel to the pre-#534 empty format, then actually
+        // corrupt the directory content underneath it — this is the state a
+        // node upgraded from before this fix, with pre-existing corruption,
+        // would be in.
+        std::fs::write(layer_dir.join(".pelagos_complete"), "").expect("truncate sentinel");
+        let victim = std::fs::read_dir(&layer_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name() != ".pelagos_complete")
+            .map(|e| e.path());
+        if let Some(victim) = victim {
+            let _ = std::fs::remove_file(&victim);
+        }
+
+        // Re-pull without `image rm` — must not report "Already present" over
+        // the corrupted-but-legacy-marked layer.
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["image", "pull", "--insecure", reference])
+            .env("PELAGOS_REGISTRIES", tmp.path())
+            .output()
+            .expect("spawn pelagos");
+        assert!(
+            out.status.success(),
+            "re-pull over legacy-marked corrupted layer should succeed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !stdout.contains("Already present"),
+            "re-pull must not silently trust a legacy-marked corrupted layer, got: {}",
+            stdout
+        );
+
+        // Sentinel should now carry a real recorded count, and integrity
+        // should pass — proving the layer was actually re-extracted, not
+        // just re-marked.
+        let recorded = std::fs::read_to_string(layer_dir.join(".pelagos_complete")).unwrap();
+        assert!(
+            !recorded.trim().is_empty(),
+            "sentinel should carry a real entry count after self-healing re-extraction"
+        );
+        assert!(
+            pelagos::image::layer_verify_integrity(digest),
+            "layer should pass integrity after self-healing re-extraction"
         );
 
         // Cleanup.


### PR DESCRIPTION
## Summary

The k3s-agent's reopening of #534 turned out to have a real signal-delivery artifact in its specific SIGKILL repro (`sudo cmd & ; kill -9 $!` only kills the `sudo` wrapper, not the child — verified independently, see issue comments) — but two separate, deterministic gaps in PR #539's fix are real regardless of that:

1. **`pull_image()`'s per-layer download loop had its own unconditioned `layer_exists()` skip**, never wired to `layer_verify_integrity()`. This loop runs on every pull (mutable tag or not), unlike the whole-image "Already present" fast path #539 patched, which only applies to non-mutable tags with an already-saved manifest.
2. **`layer_verify_integrity()` trusted an empty/legacy sentinel as "can't verify, assume OK"** for backward compatibility. Every layer extracted before #534 existed has exactly this sentinel format — including any layer already corrupted by the *original* incident, still on disk on any long-running node. Trusting it made the check a no-op for the layers it most needed to catch. A legacy sentinel now fails integrity, forcing one self-healing re-extraction per legacy layer on next reuse.

## Test plan
- [x] `cargo test --lib` — 409 passed
- [x] New test `test_pull_self_heals_legacy_marker_layer`: reproduces the cluster's exact failure mode (legacy-marked, actually-corrupted layer, re-pull without `image rm`) via a mock registry. **Fails against the pre-existing v0.65.92 code, passes after this fix.**
- [x] Full `images::`/`image_layer_atomicity::`/`image_layer_integrity::` suite green at both `--test-threads=1` (matches CI) and `=4`
- [x] `cargo fmt --check`, `cargo clippy --lib --bin pelagos -- -D warnings`
- [x] Documented the new test in `docs/INTEGRATION_TESTS.md`
- While validating, found 3 pre-existing mock-registry tests share one layer digest and are flaky under threaded runs — confirmed pre-existing (reproduces on the commit *before* this fix too), filed separately as #540, not touched here (out of scope)

Fixes #534