### PR TITLE
fix(image): image push no longer crashes re-creating a blob for an already-extracted layer

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1995,7 +1995,8 @@ fn append_dir_all_no_follow<W: io::Write>(
         // re-derivation that re-tars an already-marked directory (ensure_blob()
         // re-deriving a lost blob from its own prior output) would otherwise
         // bake this internal sentinel into the published layer content.
-        if prefix == Path::new(".") && entry.file_name() == std::ffi::OsStr::new(image::LAYER_COMPLETE_MARKER)
+        if prefix == Path::new(".")
+            && entry.file_name() == std::ffi::OsStr::new(image::LAYER_COMPLETE_MARKER)
         {
             continue;
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1120,10 +1120,19 @@ fn find_sole_wasm_file(layer_dir: &std::path::Path) -> Option<std::path::PathBuf
 }
 
 /// Recursively collect all regular files under `dir`.
+///
+/// Excludes `image::LAYER_COMPLETE_MARKER` — `create_layer_from_dir()` writes
+/// that sentinel into every layer dir it creates (#547), which would
+/// otherwise count as a second file and break `find_sole_wasm_file()`'s
+/// "exactly one file" check for a Wasm module `COPY`'d into a layer on its
+/// own (#548's regression, caught before merge).
 fn collect_layer_files(dir: &std::path::Path) -> io::Result<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
+        if entry.file_name() == std::ffi::OsStr::new(image::LAYER_COMPLETE_MARKER) {
+            continue;
+        }
         let path = entry.path();
         if path.is_dir() {
             files.extend(collect_layer_files(&path)?);
@@ -1981,6 +1990,15 @@ fn append_dir_all_no_follow<W: io::Write>(
 ) -> Result<(), io::Error> {
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
+        // Exclude image::LAYER_COMPLETE_MARKER at the layer dir's root (#547):
+        // create_layer_from_dir() writes it into every layer it creates, so a
+        // re-derivation that re-tars an already-marked directory (ensure_blob()
+        // re-deriving a lost blob from its own prior output) would otherwise
+        // bake this internal sentinel into the published layer content.
+        if prefix == Path::new(".") && entry.file_name() == std::ffi::OsStr::new(image::LAYER_COMPLETE_MARKER)
+        {
+            continue;
+        }
         let ft = entry.file_type()?; // does NOT follow symlinks
         let name = prefix.join(entry.file_name());
         let path = entry.path();
@@ -3460,5 +3478,24 @@ FROM ${NEXT} AS stage1\n";
 
         assert!(dest.join("file.txt").exists());
         assert!(!partial.exists());
+    }
+
+    /// Regression for the #547 fix itself: `create_layer_from_dir()` now
+    /// writes `image::LAYER_COMPLETE_MARKER` into every layer dir it creates.
+    /// A Wasm module `COPY`'d into a layer on its own must still be detected
+    /// as a sole-file Wasm layer — the marker must not count as a second file.
+    #[test]
+    fn collect_layer_files_excludes_completion_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("module.wasm"), b"fake wasm bytes").unwrap();
+        std::fs::write(tmp.path().join(image::LAYER_COMPLETE_MARKER), b"1").unwrap();
+
+        let files = collect_layer_files(tmp.path()).unwrap();
+
+        assert_eq!(
+            files,
+            vec![tmp.path().join("module.wasm")],
+            "the completion marker must not be counted as layer content"
+        );
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1870,7 +1870,11 @@ pub fn create_layer_from_dir(source_dir: &Path) -> Result<String, io::Error> {
         let dest = image::layer_dir(&digest_str);
         let tmp_path = tmp_dest.path().to_path_buf();
         if std::fs::rename(&tmp_path, &dest).is_err() {
-            // Cross-filesystem or rename failed — copy and set group permissions.
+            // Cross-filesystem, or dest already exists (content-addressed: same
+            // digest means same bytes, so an existing dest is already correct —
+            // e.g. re-deriving a build layer whose blob was lost but whose
+            // directory is still the canonical copy for this digest, #547).
+            // Either way, copying our content on top is safe and idempotent.
             image::create_store_dir(&dest)?;
             copy_dir_recursive(&tmp_path, &dest)?;
         } else {
@@ -1878,6 +1882,7 @@ pub fn create_layer_from_dir(source_dir: &Path) -> Result<String, io::Error> {
             use std::os::unix::fs::PermissionsExt as _;
             let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o775));
         }
+        image::mark_layer_complete(&dest)?;
 
         log::debug!("created layer {}", &hex[..12]);
         return Ok(digest_str);
@@ -1929,10 +1934,36 @@ pub fn create_layer_from_dir(source_dir: &Path) -> Result<String, io::Error> {
     }
     image::create_store_dir(&partial)?;
     copy_dir_recursive(source_dir, &partial)?;
-    std::fs::rename(&partial, &dest)?;
+    rename_into_layer_store(&partial, &dest)?;
+    image::mark_layer_complete(&dest)?;
 
     log::debug!("created layer {}", &hex[..12]);
     Ok(digest)
+}
+
+/// Rename a staged `partial` layer directory into its final content-addressed
+/// `dest` path, treating "`dest` already exists as a directory" as success
+/// rather than an error.
+///
+/// The layer store is content-addressed: a `dest` that already exists at this
+/// exact digest path already has the same bytes this rename would have
+/// produced, so a colliding `dest` is a benign race or reuse, not a real
+/// failure — this mirrors `image::extract_layer()`'s handling of the same
+/// class of collision. The common trigger is `ensure_blob()` re-deriving a
+/// build layer whose compressed blob was lost but whose extracted directory
+/// (the `source_dir` passed to `create_layer_from_dir`) is itself already the
+/// canonical copy for this digest, i.e. `dest == source_dir` — `rename` onto
+/// a non-empty directory always fails with `ENOTEMPTY` in that case (#547).
+/// Only a `dest` that doesn't exist at all after the failed rename indicates
+/// a genuine error (permission denied, disk full, etc.), which is propagated.
+fn rename_into_layer_store(partial: &Path, dest: &Path) -> io::Result<()> {
+    if let Err(e) = std::fs::rename(partial, dest) {
+        let _ = std::fs::remove_dir_all(partial);
+        if !dest.is_dir() {
+            return Err(e);
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -3378,5 +3409,56 @@ FROM ${NEXT} AS stage1\n";
             }
             _ => panic!("expected FROM instruction"),
         }
+    }
+
+    /// #547: renaming a staged `partial` onto a `dest` that already exists as
+    /// a non-empty directory must succeed, not propagate the raw `ENOTEMPTY`
+    /// io error — this is the exact collision `create_layer_from_dir` hits
+    /// when re-deriving a build layer whose blob was lost but whose extracted
+    /// directory is already the canonical copy for that digest.
+    #[test]
+    fn rename_into_layer_store_accepts_existing_nonempty_dest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("dest");
+        let partial = tmp.path().join("partial");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("file.txt"), b"content").unwrap();
+        std::fs::create_dir_all(&partial).unwrap();
+        std::fs::write(partial.join("file.txt"), b"content").unwrap();
+
+        rename_into_layer_store(&partial, &dest).unwrap();
+
+        // Original dest content survives untouched; partial is cleaned up.
+        assert!(dest.join("file.txt").exists());
+        assert!(!partial.exists());
+    }
+
+    /// A genuine failure (dest never ends up existing) must still be reported,
+    /// not silently swallowed.
+    #[test]
+    fn rename_into_layer_store_propagates_real_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let partial = tmp.path().join("nonexistent-partial");
+        let dest = tmp.path().join("no-such-parent-dir").join("dest");
+
+        let result = rename_into_layer_store(&partial, &dest);
+        assert!(result.is_err());
+    }
+
+    /// Renaming onto a genuinely empty existing `dest` directory (the normal,
+    /// non-colliding case) still succeeds via the real rename, not the
+    /// fallback branch.
+    #[test]
+    fn rename_into_layer_store_normal_rename_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("dest");
+        let partial = tmp.path().join("partial");
+        std::fs::create_dir_all(&partial).unwrap();
+        std::fs::write(partial.join("file.txt"), b"content").unwrap();
+
+        rename_into_layer_store(&partial, &dest).unwrap();
+
+        assert!(dest.join("file.txt").exists());
+        assert!(!partial.exists());
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -250,7 +250,7 @@ pub fn layer_dir(digest: &str) -> PathBuf {
 /// directory rename completes). A directory that lacks the sentinel was left by
 /// an interrupted extraction (e.g. a power cut after `rename(2)` but before
 /// the write-back completed) and must be treated as corrupt.
-const LAYER_COMPLETE_MARKER: &str = ".pelagos_complete";
+pub(crate) const LAYER_COMPLETE_MARKER: &str = ".pelagos_complete";
 
 /// Check whether a layer has already been fully extracted.
 ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -263,6 +263,30 @@ pub fn layer_exists(digest: &str) -> bool {
     dir.is_dir() && dir.join(LAYER_COMPLETE_MARKER).exists()
 }
 
+/// Write the `LAYER_COMPLETE_MARKER` sentinel into an already-populated layer
+/// directory, fsync'd so it survives a power cut (same durability contract as
+/// `extract_layer()`'s own sentinel write).
+///
+/// `create_layer_from_dir()` (build.rs) builds layers from a container's
+/// overlay upper dir rather than a pulled registry blob, and previously never
+/// wrote this marker at all — so `layer_exists()` was permanently `false` for
+/// every layer created by `pelagos build`, even when the directory was
+/// complete and correct. That made a later re-derivation (`ensure_blob()`,
+/// used by `image push`/`image save` when a layer's compressed blob is
+/// missing) always retry from scratch instead of recognizing the directory as
+/// already done — and when the recomputed digest happened to equal the
+/// source directory's own digest (the common case: identical content hashes
+/// identically), the resulting `rename(partial, dest)` collided with `dest`
+/// being `source_dir` itself, a non-empty directory, failing with
+/// `ENOTEMPTY` (#547).
+pub(crate) fn mark_layer_complete(dest: &std::path::Path) -> io::Result<()> {
+    use std::io::Write as _;
+    let entry_count = count_entries(dest).unwrap_or(0);
+    let mut f = std::fs::File::create(dest.join(LAYER_COMPLETE_MARKER))?;
+    write!(f, "{}", entry_count)?;
+    f.sync_all()
+}
+
 /// Recursively count filesystem entries (files, dirs, symlinks, devices) under
 /// `dir`, not counting `dir` itself. Used to record an extracted layer's entry
 /// count at extraction time and cheaply re-check it later without re-reading
@@ -1178,5 +1202,25 @@ mod tests {
         // Top-first for overlayfs lowerdir
         assert_eq!(dirs[0], crate::paths::layers_dir().join("top"));
         assert_eq!(dirs[1], crate::paths::layers_dir().join("bottom"));
+    }
+
+    /// #547: `create_layer_from_dir()` (build.rs) never wrote the completion
+    /// marker for layers it created, so `layer_exists()` was permanently
+    /// false for every build-created layer. `mark_layer_complete()` closes
+    /// that gap — verify it writes a readable, non-empty sentinel file that
+    /// `layer_exists()`'s own check (`dir.join(LAYER_COMPLETE_MARKER).exists()`)
+    /// would find. Uses a plain tempdir, not the real layer store — the
+    /// function only touches the path it's given.
+    #[test]
+    fn mark_layer_complete_writes_readable_sentinel() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("somefile"), b"content").unwrap();
+
+        mark_layer_complete(tmp.path()).unwrap();
+
+        let marker = tmp.path().join(LAYER_COMPLETE_MARKER);
+        assert!(marker.exists());
+        let contents = std::fs::read_to_string(&marker).unwrap();
+        assert!(!contents.is_empty(), "marker should record an entry count");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #547. `pelagos image push` (and `image save`) crashes with
`failed to re-create blob for layer <hash>: Directory not empty (os error 39)`
whenever a layer's compressed blob is missing (e.g. lost/cleaned separately from
the layer store) but the layer's extracted directory is still present, **and**
this is the second time that same layer needed re-deriving.

## Root cause

`ensure_blob()` falls back to `build::create_layer_from_dir()` when a layer's
blob is missing but its extracted directory still exists. That function re-tars
the directory's current content and computes a fresh digest — which is
generally *not* identical to the original digest (pelagos's own tar/gzip pass
doesn't bit-for-bit match however the layer was originally produced), but *is*
self-consistent: re-deriving the same source directory a second time always
recomputes the same new digest.

`create_layer_from_dir()` never wrote the `LAYER_COMPLETE_MARKER` sentinel that
`layer_exists()` checks for (unlike `extract_layer()`, the pull path) — so
`layer_exists()` was permanently `false` for every layer it created. That meant
a second re-derivation of the same source directory could never recognize its
own prior output via the existing early-return dedup check; it always fell
through to `std::fs::rename(&partial, &dest)`, which fails with `ENOTEMPTY`
once `dest` (created by the first re-derivation) already exists non-empty.

## Fix

- `image::mark_layer_complete()` writes the same sentinel `extract_layer()`
  does, now called after every successful layer creation in
  `create_layer_from_dir()` (both root and rootless paths) — so a layer this
  function creates is recognized as complete on any later lookup, not just
  layers extracted from a pull.
- `build::rename_into_layer_store()` (extracted from the root path's inline
  rename) treats a rename failure as success when `dest` already exists as a
  directory — content-addressed store, so a colliding `dest` already has the
  same bytes — mirroring `extract_layer()`'s own handling of the identical
  race.

## Testing

- Unit tests (`cargo test --release --lib -p pelagos`, run on ipc4): all pass
  except one pre-existing, unrelated environmental failure
  (`test_save_image_atomic_under_concurrent_load`, permission-denied writing
  to the real `/var/lib/pelagos` as a non-pelagos-group user — reproduces
  identically on `main`, not a regression).
- **Full end-to-end reproduction on real hardware (ipc4)**: built a real image
  via a Remfile, deleted its layer's blob, and reproduced the *exact* reported
  error (`failed to re-create blob for layer 2db175d834a3: Directory not empty
  (os error 39)`) on a `main` binary — confirmed the same push succeeds
  cleanly on this fix's binary, and that a third push short-circuits via the
  normal dedup path (no fallback needed) once the completion marker is
  present.

## Test plan

- [x] `cargo test --release --lib -p pelagos` on real Linux hardware
- [x] End-to-end repro of the exact reported error, confirmed fixed
- [ ] CI (lint + unit + integration) via the standard PR gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VjJwXw6J4QqHQviUdjJHs